### PR TITLE
Switch lists from having elements to having items

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -197,7 +197,7 @@ quotes and monospace font.
 <p>Conventionally, specifications have operated on a variety of vague specification-level data
 structures, based on shared understanding of their semantics. This generally works well, but can
 lead to ambiguities around edge cases, such as iteration order or what happens when you
-<a for=set>append</a> an element to an <a>ordered set</a> that the set already
+<a for=set>append</a> an item to an <a>ordered set</a> that the set already
 <a for=set>contains</a>. It has also led to a variety of divergent notation and phrasing, especially
 around more complex data structures such as <a lt="ordered map">maps</a>.
 
@@ -207,11 +207,11 @@ for working with them, in order to create common ground.
 <h3 id=lists>Lists</h3>
 
 <p>A <dfn export>list</dfn> is a specification type consisting of a finite ordered sequence of
-elements.
+items.
 
 <p>For notational convenience, a literal syntax can be used to express <a>lists</a>, by surrounding
-the list contents by « » characters and separating list elements with a comma. An indexing syntax
-can be used by providing a zero-based index into a list inside square brackets.
+the list contents by « » characters and separating list items with a comma. An indexing syntax can
+be used by providing a zero-based index into a list inside square brackets.
 
 <p class=example id=example-list-notation>Let |example| be the <a>list</a> « "<code>a</code>",
 "<code>b</code>", "<code>c</code>", "<code>a</code>" ». Then |example|[1] is the <a>string</a>
@@ -220,40 +220,40 @@ can be used by providing a zero-based index into a list inside square brackets.
 <hr>
 
 <p>To <dfn export for=list>append</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to add
-the given element to the end of the list.
+the given item to the end of the list.
 
 <p>To <dfn export for=list>prepend</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
-add the given element to the beginning of the list.
+add the given item to the beginning of the list.
 
 <p class=note>The above definitions are modified when the <a>list</a> is an <a>ordered set</a>; see
 below for <a for=set lt=append>ordered set append</a> and
 <a for=set lt=prepend>ordered set prepend</a>.
 
-<p>To <dfn export for=list,set>remove</dfn> an element from a <a>list</a> is to remove all elements
+<p>To <dfn export for=list,set>remove</dfn> an item from a <a>list</a> is to remove all items
 from the list that match a given condition, or do nothing if none do.
 
 <div class=example id=example-list-remove>
  <p><a for=list>Removing</a> |x| from the <a>list</a> « |x|, |y|, |z|, |x| » is to remove all
- elements from the list that are equal to |x|. The list now is equivalent to « |y|, |z| ».
+ items from the list that are equal to |x|. The list now is equivalent to « |y|, |z| ».
 
- <p><a for=list>Removing</a> all elements that start with the string "<code>a</code>" from the
+ <p><a for=list>Removing</a> all items that start with the string "<code>a</code>" from the
  <a>list</a> « "<code>a</code>", "<code>b</code>", "<code>ab</code>", "<code>ba</code>" » is to
- remove the elements "<code>a</code>" and "<code>ab</code>". The list is now equivalent to «
+ remove the items "<code>a</code>" and "<code>ab</code>". The list is now equivalent to «
  "<code>b</code>", "<code>ba</code>" ».
 </div>
 
-<p>A <a>list</a> <dfn export for=list,stack,queue,set>contains</dfn> an element if it appears in the
+<p>A <a>list</a> <dfn export for=list,stack,queue,set>contains</dfn> an item if it appears in the
 list.
 
-<p>A <a>list</a>'s <dfn export for=list,stack,queue,set>size</dfn> is the number of elements the
-list <a for=list>contains</a>.
+<p>A <a>list</a>'s <dfn export for=list,stack,queue,set>size</dfn> is the number of items the list
+<a for=list>contains</a>.
 
 <p>A <a>list</a> <dfn export for=list,stack,queue,set lt="is empty|is not empty">is empty</dfn> if
 its <a for=list>size</a> is zero.
 
 <p>To <dfn export for=list,stack,queue,set lt="iterate|for each">iterate</dfn> over a <a>list</a>,
-performing a set of steps on each element in order, use phrasing of the form
-"<a for=list>For each</a> |element| of <var ignore>list</var>", and then operate on |element| in the
+performing a set of steps on each item in order, use phrasing of the form
+"<a for=list>For each</a> |item| of <var ignore>list</var>", and then operate on |item| in the
 subsequent prose.
 
 <hr>
@@ -264,9 +264,9 @@ and provide an expanded vocabulary for manipulating <a>lists</a>. Whenever JavaS
 <a spec=ecma-262>List</a>, a <a>list</a> as defined here can be used; they are the same type.
 [[!ECMA-262]]
 
-<p>A <a>list</a> whose elements are all of a particular Web IDL type |T| can be
+<p>A <a>list</a> whose items are all of a particular Web IDL type |T| can be
 <dfn lt="convert list to sequence">converted to the corresponding <a>sequence type</a></dfn>
-<code>sequence&lt;|T|></code> by creating a sequence whose elements are the elements of the list.
+<code>sequence&lt;|T|></code> by creating a sequence whose items are the items of the list.
 [[!WEBIDL]]
 
 <h4 id=stacks>Stacks</h4>
@@ -277,7 +277,7 @@ but conventionally, the following operations are used to operate on it, instead 
 
 <p>To <dfn for=stack>push</dfn> onto a <a>stack</a> is to <a for=list>append</a> to it.
 
-<p>To <dfn for=stack>pop</dfn> from a <a>stack</a> is to <a for=list>remove</a> its last element and
+<p>To <dfn for=stack>pop</dfn> from a <a>stack</a> is to <a for=list>remove</a> its last item and
 return it, if the <a>stack</a> <a for=stack>is not empty</a>, or to return nothing otherwise.
 
 <h4 id=queues>Queues</h4>
@@ -289,13 +289,13 @@ but conventionally, the following operations are used to operate on it, instead 
 <p>To <dfn for=queue>enqueue</dfn> in a <a>queue</a> is to <a for=list>append</a> to it.
 
 <p>To <dfn for=queue>dequeue</dfn> from a <a>queue</a> is to <a for=list>remove</a> its first
-element and return it, if the <a>queue</a> <a for=queue>is not empty</a>, or to return nothing if it
+item and return it, if the <a>queue</a> <a for=queue>is not empty</a>, or to return nothing if it
 is.
 
 <h4 id=sets>Sets</h4>
 
 <p>Some <a>lists</a> are designated as <dfn export lt="ordered set|set">ordered sets</dfn>. An
-ordered set is a <a>list</a> with the additional semantic that it must not contain the same element
+ordered set is a <a>list</a> with the additional semantic that it must not contain the same item
 twice.
 
 <p class=note>Almost all cases on the web platform require an <em>ordered</em> set, instead of an
@@ -304,11 +304,11 @@ contents be consistent between browsers. In those cases where order is not requi
 ordered sets; implementations can optimize based on the fact that the order is not observable.
 
 <p>To <dfn for=set>append</dfn> to an <a>ordered set</a> is to do nothing if the set already
-<a for=list>contains</a> the given element, or to perform the normal <a>list</a>
-<a for=list>append</a> operation otherwise.
+<a for=list>contains</a> the given item, or to perform the normal <a>list</a> <a for=list>append</a>
+operation otherwise.
 
 <p>To <dfn for=set>prepend</dfn> to an <a>ordered set</a> is to do nothing if the set already
-<a for=list>contains</a> the given element, or to perform the normal <a>list</a>
+<a for=list>contains</a> the given item, or to perform the normal <a>list</a>
 <a for=list>prepend</a> operation otherwise.
 
 
@@ -347,7 +347,7 @@ exists a key/value pair with that key. We can also denote this by saying that, f
 <a>ordered map</a> |map| and key |key|, "|map|[|key|] <dfn export for=map>exists</dfn>".
 
 <p>To <dfn export for=map>get the keys</dfn> of an <a>ordered map</a>, return a new
-<a>ordered set</a> whose elements are each of the keys in the map's key/value pairs.
+<a>ordered set</a> whose items are each of the keys in the map's key/value pairs.
 
 <p>An <a>ordered map</a>'s <dfn export for=map>size</dfn> is the <a for=set>size</a> of the result
 of running <a for=map>get the keys</a> on the map.
@@ -356,7 +356,7 @@ of running <a for=map>get the keys</a> on the map.
 <a for=map>size</a> is zero.
 
 <p>To <dfn export for=map lt="iterate|for each">iterate</dfn> over an <a>ordered map</a>, performing
-a set of steps on each element in order, use phrasing of the form "<a for=list>For each</a>
+a set of steps on each item in order, use phrasing of the form "<a for=list>For each</a>
 |key| → |value| of |map|", and then operate on |key| and |value| in the subsequent prose.
 
 <hr>


### PR DESCRIPTION
This avoids confusion with the common use of the word "elements" in existing web specifications to mean HTML or XML elements. Closes #28.