### PR TITLE
Define 'continue' and 'break' statements.

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -107,55 +107,59 @@ leading spaces" or "return false") are to be interpreted with the meaning of the
 manner, so long as the end result is equivalent. (In particular, the algorithms are intended to be
 easy to follow, and not intended to be performant.)
 
+<h4 id=algorithm-control-flow>Control flow</h4>
+
 <p>The control flow of algorithms is such that a requirement to "return" or "throw" terminates the
 algorithm the statement was in. "Return" will hand the given value, if any, to its caller. "Throw"
 will make the caller automatically rethrow the given value, if any, and thereby terminate the
 caller's algorithm. Using prose the caller has the ability to "catch" the exception and perform
 another action.
 
-<p>An iteration's flow can be controlled via requirements to "continue" or "break". "Continue" will
-skip over any remaining steps in an iteration, proceeding to the next item. If no further items
-remain, the iteration will stop. "Break" will skip over any remaining steps in an iteration, and
-skip over any remaining items as well, stopping the iteration.
+<p>An iteration's flow can be controlled via requirements to
+<dfn export for=iteration>continue</dfn> or <dfn export for=iteration> break</dfn>.
+<a for=iteration>Continue</a> will skip over any remaining steps in an iteration, proceeding to the
+next item. If no further items remain, the iteration will stop. <a for=iteration>Break</a> will skip
+over any remaining steps in an iteration, and skip over any remaining items as well, stopping the
+iteration.
 
 <div class=example id=example-break-continue>
-  <p>Let |example| be the <a>list</a> « |1|, |2|, |3|, |4| ». The following prose would perform
-  <code>operation</code> upon |1|, then |2|, then |3|, then |4|:
+ <p>Let |example| be the <a>list</a> « 1, 2, 3, 4 ». The following prose would perform
+ <code>operation</code> upon 1, then 2, then 3, then 4:
 
-  <ol>
-    <li>
-      <p><a for=list>For each</a> |item| in |example|:
-      <ol>
-        <li>Perform <code>operation</code> on |item|.
-      </ol>
-    </li>
-  </ol>
+ <ol>
+  <li>
+   <p><a for=list>For each</a> |item| in |example|:
+   <ol>
+    <li>Perform <code>operation</code> on |item|.
+   </ol>
+  </li>
+ </ol>
 
-  <p>The following prose would perform <code>operation</code> upon |1|, then |2|, then |4|. |3|
-  would be skipped.
+ <p>The following prose would perform <code>operation</code> upon 1, then 2, then 4. 3 would be
+ skipped.
 
-  <ol>
-    <li>
-      <p><a for=list>For each</a> |item| in |example|:
-      <ol>
-        <li>If |item| is |3|, <strong>continue</strong>.
-        <li>Perform <code>operation</code> on |item|.
-      </ol>
-    </li>
-  </ol>
+ <ol>
+  <li>
+   <p><a for=list>For each</a> |item| in |example|:
+   <ol>
+    <li>If |item| is 3, <a for=iteration>continue</a>.
+    <li>Perform <code>operation</code> on |item|.
+   </ol>
+  </li>
+ </ol>
 
-  <p>The following prose would perform <code>operation</code> upon |1|, then |2|. |3| and |4|
-  would be skipped.
+ <p>The following prose would perform <code>operation</code> upon 1, then 2. 3 and 4 would be
+ skipped.
 
-  <ol>
-    <li>
-      <p><a for=list>For each</a> |item| in |example|:
-      <ol>
-        <li>If |item| is |3|, <strong>break</strong>.
-        <li>Perform <code>operation</code> on |item|.
-      </ol>
-    </li>
-  </ol>
+ <ol>
+  <li>
+   <p><a for=list>For each</a> |item| in |example|:
+   <ol>
+    <li>If |item| is 3, <a for=iteration>break</a>.
+    <li>Perform <code>operation</code> on |item|.
+   </ol>
+  </li>
+ </ol>
 </div>
 
 

--- a/infra.bs
+++ b/infra.bs
@@ -113,6 +113,51 @@ will make the caller automatically rethrow the given value, if any, and thereby 
 caller's algorithm. Using prose the caller has the ability to "catch" the exception and perform
 another action.
 
+<p>An iteration's flow can be controlled via requirements to "continue" or "break". "Continue" will
+skip over any remaining steps in an iteration, proceeding to the next item. If no further items
+remain, the iteration will stop. "Break" will skip over any remaining steps in an iteration, and
+skip over any remaining items as well, stopping the iteration.
+
+<div class=example id=example-break-continue>
+  <p>Let |example| be the <a>list</a> « |1|, |2|, |3|, |4| ». The following prose would perform
+  <code>operation</code> upon |1|, then |2|, then |3|, then |4|:
+
+  <ol>
+    <li>
+      <p><a for=list>For each</a> |item| in |example|:
+      <ol>
+        <li>Perform <code>operation</code> on |item|.
+      </ol>
+    </li>
+  </ol>
+
+  <p>The following prose would perform <code>operation</code> upon |1|, then |2|, then |4|. |3|
+  would be skipped.
+
+  <ol>
+    <li>
+      <p><a for=list>For each</a> |item| in |example|:
+      <ol>
+        <li>If |item| is |3|, <strong>continue</strong>.
+        <li>Perform <code>operation</code> on |item|.
+      </ol>
+    </li>
+  </ol>
+
+  <p>The following prose would perform <code>operation</code> upon |1|, then |2|. |3| and |4|
+  would be skipped.
+
+  <ol>
+    <li>
+      <p><a for=list>For each</a> |item| in |example|:
+      <ol>
+        <li>If |item| is |3|, <strong>break</strong>.
+        <li>Perform <code>operation</code> on |item|.
+      </ol>
+    </li>
+  </ol>
+</div>
+
 
 <h3 id=terminology>Terminology</h3>
 
@@ -286,53 +331,6 @@ its <a for=list>size</a> is zero.
 performing a set of steps on each item in order, use phrasing of the form
 "<a for=list>For each</a> |item| of <var ignore>list</var>", and then operate on |item| in the
 subsequent prose.
-
-<p>Inside a <a for=list>for each</a> construct, individual items may be skipped by writing
-"<dfn for='for each'>continue</dfn>". That restarts the loop using the next item in the list,
-or exits the loop entirely if no further items remain.
-
-<p>The <a for=list>for each</a> construct can exit early by writing
-"<dfn for='for each'>break</dfn>". That exits the loop, skipping any remaining item in the list.
-
-<div class=example id=example-for-each-continue>
-  <p>Let |example| be the <a>list</a> « |1|, |2|, |3|, |4| ». The following prose would perform
-  <code>operation</code> upon |1|, then |2|, then |3|, then |4|:
-
-  <ol>
-    <li>
-      <p><a for=list>For each</a> |item| in |example|:
-      <ol>
-        <li>Perform <code>operation</code> on |item|.                                                                             
-      </ol>
-    </li>
-  </ol>
-
-  <p>The following prose would perform <code>operation</code> upon |1|, then |2|, then |4|. |3|
-  would be skipped.
-
-  <ol>
-    <li>
-      <p><a for=list>For each</a> |item| in |example|:
-      <ol>
-        <li>If |item| is |3|, <a for='for each'>continue</a>.
-        <li>Perform <code>operation</code> on |item|.
-      </ol>
-    </li>
-  </ol>
-
-  <p>The following prose would perform <code>operation</code> upon |1|, then |2|. |3| and |4|
-  would be skipped.
-
-  <ol>
-    <li>
-      <p><a for=list>For each</a> |item| in |example|:
-      <ol>
-        <li>If |item| is |3|, <a for='for each'>break</a>.
-        <li>Perform <code>operation</code> on |item|.
-      </ol>
-    </li>
-  </ol>
-</div>
 
 <hr>
 

--- a/infra.bs
+++ b/infra.bs
@@ -123,40 +123,38 @@ over any remaining steps in an iteration, and skip over any remaining items as w
 iteration.
 
 <div class=example id=example-break-continue>
- <p>Let |example| be the <a>list</a> « 1, 2, 3, 4 ». The following prose would perform
- <code>operation</code> upon 1, then 2, then 3, then 4:
+ <p>Let |example| be the <a>list</a> « 1, 2, 3, 4 ». The following prose would perform |operation|
+ upon 1, then 2, then 3, then 4:
 
  <ol>
   <li>
    <p><a for=list>For each</a> |item| in |example|:
    <ol>
-    <li>Perform <code>operation</code> on |item|.
+    <li>Perform |operation| on |item|.
    </ol>
   </li>
  </ol>
 
- <p>The following prose would perform <code>operation</code> upon 1, then 2, then 4. 3 would be
- skipped.
+ <p>The following prose would perform |operation| upon 1, then 2, then 4. 3 would be skipped.
 
  <ol>
   <li>
    <p><a for=list>For each</a> |item| in |example|:
    <ol>
-    <li>If |item| is 3, <a for=iteration>continue</a>.
-    <li>Perform <code>operation</code> on |item|.
+    <li>If |item| is 3, then <a for=iteration>continue</a>.
+    <li>Perform |operation| on |item|.
    </ol>
   </li>
  </ol>
 
- <p>The following prose would perform <code>operation</code> upon 1, then 2. 3 and 4 would be
- skipped.
+ <p>The following prose would perform |operation| upon 1, then 2. 3 and 4 would be skipped.
 
  <ol>
   <li>
    <p><a for=list>For each</a> |item| in |example|:
    <ol>
-    <li>If |item| is 3, <a for=iteration>break</a>.
-    <li>Perform <code>operation</code> on |item|.
+    <li>If |item| is 3, then <a for=iteration>break</a>.
+    <li>Perform |operation| on |item|.
    </ol>
   </li>
  </ol>

--- a/infra.bs
+++ b/infra.bs
@@ -116,7 +116,7 @@ caller's algorithm. Using prose the caller has the ability to "catch" the except
 another action.
 
 <p>An iteration's flow can be controlled via requirements to
-<dfn export for=iteration>continue</dfn> or <dfn export for=iteration> break</dfn>.
+<dfn export for=iteration>continue</dfn> or <dfn export for=iteration>break</dfn>.
 <a for=iteration>Continue</a> will skip over any remaining steps in an iteration, proceeding to the
 next item. If no further items remain, the iteration will stop. <a for=iteration>Break</a> will skip
 over any remaining steps in an iteration, and skip over any remaining items as well, stopping the

--- a/infra.bs
+++ b/infra.bs
@@ -287,6 +287,53 @@ performing a set of steps on each item in order, use phrasing of the form
 "<a for=list>For each</a> |item| of <var ignore>list</var>", and then operate on |item| in the
 subsequent prose.
 
+<p>Inside a <a for=list>for each</a> construct, individual items may be skipped by writing
+"<dfn for='for each'>continue</dfn>". That restarts the loop using the next item in the list,
+or exits the loop entirely if no further items remain.
+
+<p>The <a for=list>for each</a> construct can exit early by writing
+"<dfn for='for each'>break</dfn>". That exits the loop, skipping any remaining item in the list.
+
+<div class=example id=example-for-each-continue>
+  <p>Let |example| be the <a>list</a> « |1|, |2|, |3|, |4| ». The following prose would perform
+  <code>operation</code> upon |1|, then |2|, then |3|, then |4|:
+
+  <ol>
+    <li>
+      <p><a for=list>For each</a> |item| in |example|:
+      <ol>
+        <li>Perform <code>operation</code> on |item|.                                                                             
+      </ol>
+    </li>
+  </ol>
+
+  <p>The following prose would perform <code>operation</code> upon |1|, then |2|, then |4|. |3|
+  would be skipped.
+
+  <ol>
+    <li>
+      <p><a for=list>For each</a> |item| in |example|:
+      <ol>
+        <li>If |item| is |3|, <a for='for each'>continue</a>.
+        <li>Perform <code>operation</code> on |item|.
+      </ol>
+    </li>
+  </ol>
+
+  <p>The following prose would perform <code>operation</code> upon |1|, then |2|. |3| and |4|
+  would be skipped.
+
+  <ol>
+    <li>
+      <p><a for=list>For each</a> |item| in |example|:
+      <ol>
+        <li>If |item| is |3|, <a for='for each'>break</a>.
+        <li>Perform <code>operation</code> on |item|.
+      </ol>
+    </li>
+  </ol>
+</div>
+
 <hr>
 
 <p>The <a>list</a> type originates from the JavaScript specification (where it is capitalized, as

--- a/infra.bs
+++ b/infra.bs
@@ -475,6 +475,7 @@ for each pair of converted key/original value. [[!WEBIDL]]
 
 <p>Many thanks to
 Michael™ Smith,
+Mike West,
 Philip Jägenstedt,
 and Simon Pieters
 for being awesome!


### PR DESCRIPTION
This patch defines 'continue' and 'break' in the context of a 'for each' loop, and
provides simple examples of their usage.

This addresses pieces of https://github.com/whatwg/infra/issues/22, leaving
'continue to' for a subsequent patch.