### PR TITLE
Remove extra 'if'

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -624,6 +624,7 @@ subsequent prose.
 <h2 class=no-num id=acknowledgments>Acknowledgments</h2>
 
 <p>Many thanks to
+Dominic Farolino,
 Jungkee Song,
 Malika Aubakirova,
 Michael™ Smith,

--- a/infra.bs
+++ b/infra.bs
@@ -570,7 +570,7 @@ a comma. An indexing syntax can be used to look up and set <a for=map>values</a>
 
 <p>To <dfn export for=map lt="get|get the value">get the value of an entry</dfn> in an
 <a>ordered map</a> given a <a for=map>key</a> is to retrieve the <a for=map>value</a> of any
-existing <a for=map>entry</a> if the map <a for=map>contains</a> an entry with the given key, or if
+existing <a for=map>entry</a> if the map <a for=map>contains</a> an entry with the given key, or
 to return nothing otherwise. We can also use the indexing syntax explained above.
 
 <p>To <dfn export for=map lt="set|set the value">set the value of an entry</dfn> in an


### PR DESCRIPTION
Seems like the `if` was extraneous


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/domfarolino/infra/master.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/8e8d83d...domfarolino:b663055.html)