### PR TITLE
Add the "empty a list" operation

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -481,7 +481,8 @@ all items from the list that match a given condition, or do nothing if none do.
  "<code>b</code>", "<code>ba</code>" ».
 </div>
 
-<p>To <dfn export for=list,stack,queue,set>empty</dfn> a <a>list</a> is to remove all of its items.
+<p>To <dfn export for=list,stack,queue,set>empty</dfn> a <a>list</a> is to <a for=list>remove</a>
+all of its items.
 
 <p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain>contains</dfn> an
 <a for=list>item</a> if it appears in the list.

--- a/infra.bs
+++ b/infra.bs
@@ -481,6 +481,8 @@ all items from the list that match a given condition, or do nothing if none do.
  "<code>b</code>", "<code>ba</code>" ».
 </div>
 
+<p>To <dfn export for=list,stack,queue,set>empty</dfn> a <a>list</a> is to remove all of its items.
+
 <p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain>contains</dfn> an
 <a for=list>item</a> if it appears in the list.
 
@@ -509,9 +511,9 @@ and provide an expanded vocabulary for manipulating <a>lists</a>. Whenever JavaS
 but conventionally, the following operations are used to operate on it, instead of using
 <a for=list>append</a>, <a for=list>prepend</a>, or <a for=list>remove</a>.
 
-<p>To <dfn for=stack>push</dfn> onto a <a>stack</a> is to <a for=list>append</a> to it.
+<p>To <dfn export for=stack>push</dfn> onto a <a>stack</a> is to <a for=list>append</a> to it.
 
-<p>To <dfn for=stack>pop</dfn> from a <a>stack</a> is to <a for=list>remove</a> its last
+<p>To <dfn export for=stack>pop</dfn> from a <a>stack</a> is to <a for=list>remove</a> its last
 <a for=stack>item</a> and return it, if the <a>stack</a> <a for=stack>is not empty</a>, or to return
 nothing otherwise.
 
@@ -521,9 +523,9 @@ nothing otherwise.
 but conventionally, the following operations are used to operate on it, instead of using
 <a for=list>append</a>, <a for=list>prepend</a>, or <a for=list>remove</a>.
 
-<p>To <dfn for=queue>enqueue</dfn> in a <a>queue</a> is to <a for=list>append</a> to it.
+<p>To <dfn export for=queue>enqueue</dfn> in a <a>queue</a> is to <a for=list>append</a> to it.
 
-<p>To <dfn for=queue>dequeue</dfn> from a <a>queue</a> is to <a for=list>remove</a> its first
+<p>To <dfn export for=queue>dequeue</dfn> from a <a>queue</a> is to <a for=list>remove</a> its first
 <a for=queue>item</a> and return it, if the <a>queue</a> <a for=queue>is not empty</a>, or to return
 nothing if it is.
 


### PR DESCRIPTION
Also, export some list-adjacent terms.

Both changes will be useful in https://github.com/whatwg/console/pull/95.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/more-list-stuff/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/f4d2de2...da1c3e7.html)