### PR TITLE
Note how to get a byte sequence out of a string

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -194,6 +194,9 @@ actual <a>string</a>.
  <p>Headers, such as `<code>Content-Type</code>`, are <a>byte sequences</a>.
 </div>
 
+<p class=note>To get a <a>byte sequence</a> out of a <a>string</a>, use an operation such as
+<a>UTF-8 encode</a> from the Encoding Standard. [[ENCODING]]
+
 <p>To <dfn export>byte-lowercase</dfn> a <a>byte sequence</a>, increase each <a>byte</a> it
 contains, in the range 0x41 to 0x5A, inclusive, by 0x20.
 


### PR DESCRIPTION
Fixes #9.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/annevk/string-to-byte-tip/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/f4d2de2...6caef2c.html)