### PR TITLE
Limit the bytes you can express as string more

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -184,7 +184,7 @@ number in the range 0x00 to 0xFF, inclusive.
 <h3 id=byte-sequences>Byte sequences</h3>
 
 <p>A <dfn export>byte sequence</dfn> is a sequence of <a>bytes</a>, represented as a space-separated
-sequence of bytes. Byte sequences with bytes in the range 0x00 to 0x7F, inclusive, can alternately
+sequence of bytes. Byte sequences with bytes in the range 0x20 to 0x7F, inclusive, can alternately
 be written as a string, but using backticks instead of quotation marks, to avoid confusion with an
 actual <a>string</a>.
 


### PR DESCRIPTION
Fixes #63.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/annevk/byte-sequence-representation/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/f4d2de2...650dedf.html)