### PR TITLE
Define exists for lists and boundaries of list [] syntax

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -541,7 +541,7 @@ all of its items.
 
 <p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain|exists>contains</dfn> an
 <a for=list>item</a> if it appears in the list. We can also denote this by saying that, for a
-<a>list</a> |list| and an <a for=list>item</a> |item|, "|list|[|item|] <a for=list>exists</a>".
+<a>list</a> |list| and an index |index|, "|list|[|index|] <a for=list>exists</a>".
 
 <p>A <a>list</a>'s <dfn export for=list,stack,queue,set>size</dfn> is the number of
 <a for=list>items</a> the list <a for=list>contains</a>.

--- a/infra.bs
+++ b/infra.bs
@@ -504,7 +504,8 @@ for working with them, in order to create common ground.
 
 <p>For notational convenience, a literal syntax can be used to express <a>lists</a>, by surrounding
 the list by « » characters and separating its <a for=list>items</a> with a comma. An indexing syntax
-can be used by providing a zero-based index into a list inside square brackets.
+can be used by providing a zero-based index into a list inside square brackets. The index cannot be
+out-of-bounds, except when used with <a for=list>exists</a>.
 
 <p class=example id=example-list-notation>Let |example| be the <a>list</a> « "<code>a</code>",
 "<code>b</code>", "<code>c</code>", "<code>a</code>" ». Then |example|[1] is the <a>string</a>
@@ -538,8 +539,9 @@ all items from the list that match a given condition, or do nothing if none do.
 <p>To <dfn export for=list,stack,queue,set>empty</dfn> a <a>list</a> is to <a for=list>remove</a>
 all of its items.
 
-<p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain>contains</dfn> an
-<a for=list>item</a> if it appears in the list.
+<p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain|exists>contains</dfn> an
+<a for=list>item</a> if it appears in the list. We can also denote this by saying that, for a
+<a>list</a> |list| and an <a for=list>item</a> |item|, "|list|[|item|] <a for=list>exists</a>".
 
 <p>A <a>list</a>'s <dfn export for=list,stack,queue,set>size</dfn> is the number of
 <a for=list>items</a> the list <a for=list>contains</a>.


### PR DESCRIPTION
Fixes #90.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/annevk/list-boundaries/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/139484a...bf9633d.html)