### PR TITLE
Make set replacement more limited in scope

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -728,9 +728,16 @@ ordered sets; implementations can optimize based on the fact that the order is n
 <a for=list>contains</a> the given <a for=set>item</a>, or to perform the normal <a>list</a>
 <a for=list>prepend</a> operation otherwise.
 
-<p>To <dfn export for=set>replace</dfn> within an <a>ordered set</a> is to replace the first item
-from the set that matches a given condition with the given <a for=set>item</a> and remove the other
-matching items, or do nothing if none match.
+<p>To <dfn export for=set>replace</dfn> within an <a>ordered set</a>, given <var>item</var>,
+<var>set</var>, and <var>replacement</var>, is to run these steps:
+
+<ol>
+ <li><p>If <var>set</var>[<var>replacement</var>] <a for=set>exists</a>, then <a>remove</a>
+ <var>item</var> from <var>set</var>.
+
+ <li><p>Otherwise, if <var>set</var>[<var>item</var>] <a for=set>exists</a>, replace <var>item</var>
+ within <var>set</var> with <var>replacement</var>.
+</ol>
 
 <hr>
 
@@ -869,6 +876,7 @@ as 200/`<code>OK</code>`.
 
 <p>Many thanks to
 Addison Phillips,
+Aryeh Gregor,
 Dominic Farolino,
 Jake Archibald,
 Jungkee Song,

--- a/infra.bs
+++ b/infra.bs
@@ -729,15 +729,12 @@ ordered sets; implementations can optimize based on the fact that the order is n
 <a for=list>prepend</a> operation otherwise.
 
 <p>To <dfn export for=set>replace</dfn> within an <a>ordered set</a>, given <var>item</var>,
-<var>set</var>, and <var>replacement</var>, is to run these steps:
+<var>set</var>, and <var>replacement</var> is to: if <var>set</var> <a for=set>contains</a>
+<var>item</var> or <var>replacement</var>, then replace the first instance of either with
+<var>replacement</var> and <a>remove</a> all other instances.
 
-<ol>
- <li><p>If <var>set</var>[<var>replacement</var>] <a for=set>exists</a>, then <a>remove</a>
- <var>item</var> from <var>set</var>.
-
- <li><p>Otherwise, if <var>set</var>[<var>item</var>] <a for=set>exists</a>, replace <var>item</var>
- within <var>set</var> with <var>replacement</var>.
-</ol>
+<p class=example id=example-set-replace>Replacing "a" with "c" within a <a>set</a> « "a", "b", "c" »
+gives « "c", "b" ». Within « "c", "b", "a" » it gives « "c", "b" » as well.
 
 <hr>
 

--- a/infra.bs
+++ b/infra.bs
@@ -728,13 +728,14 @@ ordered sets; implementations can optimize based on the fact that the order is n
 <a for=list>contains</a> the given <a for=set>item</a>, or to perform the normal <a>list</a>
 <a for=list>prepend</a> operation otherwise.
 
-<p>To <dfn export for=set>replace</dfn> within an <a>ordered set</a>, given <var>item</var>,
-<var>set</var>, and <var>replacement</var> is to: if <var>set</var> <a for=set>contains</a>
-<var>item</var> or <var>replacement</var>, then replace the first instance of either with
-<var>replacement</var> and <a>remove</a> all other instances.
+<p>To <dfn export for=set lt=replace|replacing>replace</dfn> within an <a>ordered set</a>
+<var>set</var>, given <var>item</var> and <var>replacement</var>: if <var>set</var>
+<a for=set>contains</a> <var>item</var> or <var>replacement</var>, then replace the first instance
+of either with <var>replacement</var> and <a for=set>remove</a> all other instances.
 
-<p class=example id=example-set-replace>Replacing "a" with "c" within a <a>set</a> « "a", "b", "c" »
-gives « "c", "b" ». Within « "c", "b", "a" » it gives « "c", "b" » as well.
+<p class=example id=example-set-replace><a for="set">Replacing</a> "a" with "c" within the
+<a>ordered set</a> « "a", "b", "c" » gives « "c", "b" ». Within « "c", "b", "a" » it gives
+« "c", "b" » as well.
 
 <hr>
 


### PR DESCRIPTION
Per discussion in https://github.com/whatwg/dom/issues/442.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/annevk/set-replace/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/fa61fb2...6969703.html)