### PR TITLE
Remove erroneous step in "split on ASCII whitespace"

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -544,8 +544,6 @@ interspersed <a>ASCII whitespace</a>.
 
  <li><p><a>Skip ASCII whitespace</a> within <var>input</var> given <var>position</var>.
 
- <li><p><a for="list">Append</a> <var>token</var> to <var>tokens</var>.
-
  <li>
   <p>While <var>position</var> is not past the end of <var>input</var>:
 
@@ -891,6 +889,7 @@ Sergey Shekyan,
 Simon Pieters,
 Tab Atkins,
 Tobie Langel,
+triple-underscore,
 and Xue Fuqiao
 for being awesome!
 


### PR DESCRIPTION
Closes #131.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/fix-split/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/aa54c36...19eaa99.html)