### PR TITLE
Export tuple/item dfn.

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -831,7 +831,7 @@ subsequent prose.
 <h3 id=structs>Structs</h3>
 
 <p>A <dfn export>struct</dfn> is a specification type consisting of a finite set of
-<dfn for=struct,tuple,pair lt=item>items</dfn>, each of which has a unique and immutable
+<dfn export for=struct,tuple,pair lt=item>items</dfn>, each of which has a unique and immutable
 <dfn export for=struct,tuple,pair>name</dfn>.
 
 <hr>


### PR DESCRIPTION
This was not exported for some reason.

Needed for WebIDL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/infra/export-tuple-item.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/51f0a41...tobie:2af440a.html)