### PR TITLE
Define forgiving-base64

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -899,8 +899,8 @@ certain inputs.
 <p>To <dfn export>forgiving-base64 decode</dfn> given a string <var>data</var>, run these steps:</p>
 
 <ol>
- <li><p>Let <var>position</var> be a pointer into <var>data</var>, initially pointing at the start
- of the string.
+ <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially
+ pointing at the start of <var>data</var>.
 
  <li><p>Remove all <a>ASCII whitespace</a> from <var>data</var>.
 
@@ -1020,7 +1020,6 @@ certain inputs.
    order, and then empty <var>buffer</var>.
 
    <li><p>Advance <var>position</var> by 1.
-
   </ol>
 
  <li>

--- a/infra.bs
+++ b/infra.bs
@@ -894,7 +894,7 @@ certain inputs.
   <ul class="brief">
    <li>U+002B (+)
    <li>U+002F (/)
-   <li><span>ASCII alphanumeric</span>
+   <li><a>ASCII alphanumeric</a>
   </ul>
 
   <p>then return failure.

--- a/infra.bs
+++ b/infra.bs
@@ -16,20 +16,6 @@ Abstract: The Infra Standard aims to define the fundamental concepts upon which 
 Boilerplate: omit conformance, omit feedback-header, omit idl-index
 </pre>
 
-<style>
-#base64-table {
-  white-space: nowrap;
-  font-size: 0.6em;
-  column-width: 6em;
-  column-count: 5;
-  column-gap: 1em;
-}
-#base64-table thead { display: none; }
-#base64-table * { border: none; }
-#base64-table tbody td:first-child:after { content: ':'; }
-#base64-table tbody td:last-child { text-align: right; }
-</style>
-
 <script src=https://resources.whatwg.org/file-issue.js async></script>
 <script src=https://resources.whatwg.org/commit-snapshot-shortcut-key.js async></script>
 <script src=https://resources.whatwg.org/dfn.js defer></script>
@@ -899,13 +885,11 @@ certain inputs.
 <p>To <dfn export>forgiving-base64 decode</dfn> given a string <var>data</var>, run these steps:</p>
 
 <ol>
- <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially
- pointing at the start of <var>data</var>.
-
  <li><p>Remove all <a>ASCII whitespace</a> from <var>data</var>.
+ <!-- https://lists.w3.org/Archives/Public/public-whatwg-archive/2011May/0207.html -->
 
  <li>
-  <p>If <var>data</var> contains a code point that is not one of
+  <p>If <var>data</var> contains a <a>code point</a> that is not one of
 
   <ul class="brief">
    <li>U+002B (+)
@@ -919,8 +903,8 @@ certain inputs.
   <p>If <var>data</var>'s <a for=string>length</a> divides by 4 leaving no remainder, then:
 
   <ol>
-   <li><p>If <var>data</var> ends with one or two U+003D (=) characters, then remove them from
-   <var>data</var>.
+   <li><p>If <var>data</var> ends with one or two U+003D (=) <a>code points</a>, then remove them
+   from <var>data</var>.
   </ol>
 
  <li><p>If <var>data</var>'s <a for=string>length</a> divides by 4 leaving a remainder of 1, then
@@ -930,87 +914,16 @@ certain inputs.
 
  <li><p>Let <var>buffer</var> be an empty buffer that can have bits appended to it.
 
+ <li><p>Let <var>position</var> be a <a>position variable</a> for <var>data</var>, initially
+ pointing at the start of <var>data</var>.
+
  <li>
   <p>While <var>position</var> does not point past the end of <var>data</var>:
 
   <ol>
-   <li>
-    <p>Find the character pointed to by <var>position</var> in the first column of the following
-    table. Let <var>n</var> be the number given in the second cell of the same row.</p>
-
-    <div id="base64-table">
-     <table>
-      <thead>
-       <tr>
-        <th>Character
-        <th>Number
-      <tbody>
-       <tr><td>A<td>0
-       <tr><td>B<td>1
-       <tr><td>C<td>2
-       <tr><td>D<td>3
-       <tr><td>E<td>4
-       <tr><td>F<td>5
-       <tr><td>G<td>6
-       <tr><td>H<td>7
-       <tr><td>I<td>8
-       <tr><td>J<td>9
-       <tr><td>K<td>10
-       <tr><td>L<td>11
-       <tr><td>M<td>12
-       <tr><td>N<td>13
-       <tr><td>O<td>14
-       <tr><td>P<td>15
-       <tr><td>Q<td>16
-       <tr><td>R<td>17
-       <tr><td>S<td>18
-       <tr><td>T<td>19
-       <tr><td>U<td>20
-       <tr><td>V<td>21
-       <tr><td>W<td>22
-       <tr><td>X<td>23
-       <tr><td>Y<td>24
-       <tr><td>Z<td>25
-       <tr><td>a<td>26
-       <tr><td>b<td>27
-       <tr><td>c<td>28
-       <tr><td>d<td>29
-       <tr><td>e<td>30
-       <tr><td>f<td>31
-       <tr><td>g<td>32
-       <tr><td>h<td>33
-       <tr><td>i<td>34
-       <tr><td>j<td>35
-       <tr><td>k<td>36
-       <tr><td>l<td>37
-       <tr><td>m<td>38
-       <tr><td>n<td>39
-       <tr><td>o<td>40
-       <tr><td>p<td>41
-       <tr><td>q<td>42
-       <tr><td>r<td>43
-       <tr><td>s<td>44
-       <tr><td>t<td>45
-       <tr><td>u<td>46
-       <tr><td>v<td>47
-       <tr><td>w<td>48
-       <tr><td>x<td>49
-       <tr><td>y<td>50
-       <tr><td>z<td>51
-       <tr><td>0<td>52
-       <tr><td>1<td>53
-       <tr><td>2<td>54
-       <tr><td>3<td>55
-       <tr><td>4<td>56
-       <tr><td>5<td>57
-       <tr><td>6<td>58
-       <tr><td>7<td>59
-       <tr><td>8<td>60
-       <tr><td>9<td>61
-       <tr><td>+<td>62
-       <tr><td>/<td>63
-     </table>
-    </div>
+   <li><p>Find the <a>code point</a> pointed to by <var>position</var> in the second column of
+   Table 1: The Base 64 Alphabet of RFC 4648. Let <var>n</var> be the number given in the first cell
+   of the same row. [[!RFC4648]]
 
    <li><p>Append the six bits corresponding to <var>number</var>, most significant bit first, to
    <var>buffer</var>.

--- a/infra.bs
+++ b/infra.bs
@@ -16,6 +16,20 @@ Abstract: The Infra Standard aims to define the fundamental concepts upon which 
 Boilerplate: omit conformance, omit feedback-header, omit idl-index
 </pre>
 
+<style>
+#base64-table {
+  white-space: nowrap;
+  font-size: 0.6em;
+  column-width: 6em;
+  column-count: 5;
+  column-gap: 1em;
+}
+#base64-table thead { display: none; }
+#base64-table * { border: none; }
+#base64-table tbody td:first-child:after { content: ':'; }
+#base64-table tbody td:last-child { text-align: right; }
+</style>
+
 <script src=https://resources.whatwg.org/file-issue.js async></script>
 <script src=https://resources.whatwg.org/commit-snapshot-shortcut-key.js async></script>
 <script src=https://resources.whatwg.org/dfn.js defer></script>
@@ -870,6 +884,157 @@ For <a>pairs</a>, a slightly shorter literal syntax can be used, separating the 
 
 <p class=example id=example-pair>Another way of expressing our |statusInstance| tuple above would be
 as 200/`<code>OK</code>`.
+
+
+<h2 id=forgiving-base64>Forgiving base64</h2>
+
+<p>To <dfn export>forgiving-base64 encode</dfn> given a <a>byte sequence</a> <var>data</var>, apply
+the base64 algorithm defined in section 4 of RFC 4648 to <var>data</var> and return the result.
+[[!RFC4648]]
+
+<p class="note no-backref">This is named <a>forgiving-base64 encode</a> for symmetry with
+<a>forgiving-base64 decode</a>, which is different from the RFC as it defines error handling for
+certain inputs.
+
+<p>To <dfn export>forgiving-base64 decode</dfn> given a string <var>data</var>, run these steps:</p>
+
+<ol>
+ <li><p>Let <var>position</var> be a pointer into <var>data</var>, initially pointing at the start
+ of the string.
+
+ <li><p>Remove all <a>ASCII whitespace</a> from <var>data</var>.
+
+ <li>
+  <p>If <var>data</var> contains a code point that is not one of
+
+  <ul class="brief">
+   <li>U+002B (+)
+   <li>U+002F (/)
+   <li><span>ASCII alphanumeric</span>
+  </ul>
+
+  <p>then return failure.
+
+ <li>
+  <p>If <var>data</var>'s <a for=string>length</a> divides by 4 leaving no remainder, then:
+
+  <ol>
+   <li><p>If <var>data</var> ends with one or two U+003D (=) characters, then remove them from
+   <var>data</var>.
+  </ol>
+
+ <li><p>If <var>data</var>'s <a for=string>length</a> divides by 4 leaving a remainder of 1, then
+ return failure.
+
+ <li><p>Let <var>output</var> be an empty <a>byte sequence</a>.
+
+ <li><p>Let <var>buffer</var> be an empty buffer that can have bits appended to it.
+
+ <li>
+  <p>While <var>position</var> does not point past the end of <var>data</var>:
+
+  <ol>
+   <li>
+    <p>Find the character pointed to by <var>position</var> in the first column of the following
+    table. Let <var>n</var> be the number given in the second cell of the same row.</p>
+
+    <div id="base64-table">
+     <table>
+      <thead>
+       <tr>
+        <th>Character
+        <th>Number
+      <tbody>
+       <tr><td>A<td>0
+       <tr><td>B<td>1
+       <tr><td>C<td>2
+       <tr><td>D<td>3
+       <tr><td>E<td>4
+       <tr><td>F<td>5
+       <tr><td>G<td>6
+       <tr><td>H<td>7
+       <tr><td>I<td>8
+       <tr><td>J<td>9
+       <tr><td>K<td>10
+       <tr><td>L<td>11
+       <tr><td>M<td>12
+       <tr><td>N<td>13
+       <tr><td>O<td>14
+       <tr><td>P<td>15
+       <tr><td>Q<td>16
+       <tr><td>R<td>17
+       <tr><td>S<td>18
+       <tr><td>T<td>19
+       <tr><td>U<td>20
+       <tr><td>V<td>21
+       <tr><td>W<td>22
+       <tr><td>X<td>23
+       <tr><td>Y<td>24
+       <tr><td>Z<td>25
+       <tr><td>a<td>26
+       <tr><td>b<td>27
+       <tr><td>c<td>28
+       <tr><td>d<td>29
+       <tr><td>e<td>30
+       <tr><td>f<td>31
+       <tr><td>g<td>32
+       <tr><td>h<td>33
+       <tr><td>i<td>34
+       <tr><td>j<td>35
+       <tr><td>k<td>36
+       <tr><td>l<td>37
+       <tr><td>m<td>38
+       <tr><td>n<td>39
+       <tr><td>o<td>40
+       <tr><td>p<td>41
+       <tr><td>q<td>42
+       <tr><td>r<td>43
+       <tr><td>s<td>44
+       <tr><td>t<td>45
+       <tr><td>u<td>46
+       <tr><td>v<td>47
+       <tr><td>w<td>48
+       <tr><td>x<td>49
+       <tr><td>y<td>50
+       <tr><td>z<td>51
+       <tr><td>0<td>52
+       <tr><td>1<td>53
+       <tr><td>2<td>54
+       <tr><td>3<td>55
+       <tr><td>4<td>56
+       <tr><td>5<td>57
+       <tr><td>6<td>58
+       <tr><td>7<td>59
+       <tr><td>8<td>60
+       <tr><td>9<td>61
+       <tr><td>+<td>62
+       <tr><td>/<td>63
+     </table>
+    </div>
+
+   <li><p>Append the six bits corresponding to <var>number</var>, most significant bit first, to
+   <var>buffer</var>.
+
+   <li><p>If <var>buffer</var> has accumulated 24 bits, interpret them as three 8-bit big-endian
+   numbers. Append three bytes with values equal to those numbers to <var>output</var>, in the same
+   order, and then empty <var>buffer</var>.
+
+   <li><p>Advance <var>position</var> by 1.
+
+  </ol>
+
+ <li>
+  <p>If <var>buffer</var> is not empty, it contains either 12 or 18 bits. If it contains 12 bits,
+  then discard the last four and interpret the remaining eight as an 8-bit big-endian number. If it
+  contains 18 bits, then discard the last two and interpret the remaining 16 as two 8-bit big-endian
+  numbers. Append the one or two bytes with values equal to those one or two numbers to
+  <var>output</var>, in the same order.</p>
+
+  <p class="note">The discarded bits mean that, for instance, "<code>YQ</code>" and
+  "<code>YR</code>" both return `<code>a</code>`.
+
+ <li><p>Return <var>output</var>.
+</ol>
 
 
 <h2 id=namespaces>Namespaces</h2>


### PR DESCRIPTION
For use by window.btoa()/window.atob() and data: URLs. Much of this text originated in the HTML Standard.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/annevk/base64/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/d28f5cd...8a6d030.html)