### PR TITLE
byte sequence <> string

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -313,13 +313,10 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 <a>byte sequence</a> <var>B</var>, if the <a>byte-lowercase</a> of <var>A</var> is the
 <a>byte-lowercase</a> of <var>B</var>.
 
-<p>To <dfn export for="byte sequence">map</dfn> a <a>byte sequence</a> <var>input</var> to a
-<a>string</a>, return a string whose <a for=string>length</a> is equal to <var>input</var>'s
+<p>To <dfn export>isomorphic decode</dfn> a <a>byte sequence</a> <var>input</var>, return a
+<a>string</a> whose <a for=string>length</a> is equal to <var>input</var>'s
 <a for="byte sequence">length</a> and whose code points have the same values as <var>input</var>'s
 bytes, in the same order.
-
-<p class=note>This matches the behavior of a ISO-8859-1 decoder, except no such decoder is defined
-as the Encoding Standard maps "<code>iso-8859-1</code>" to <a>windows-1252</a>. [[ENCODING]]
 
 <h3 id=code-points>Code points</h3>
 
@@ -458,8 +455,7 @@ implementations of just <a>JavaScript strings</a> for performance and memory rea
 
 <hr>
 
-<p>To <dfn export for=string>map</dfn> a <a>string</a> <var>input</var> to a <a>byte sequence</a>,
-run these steps:</p>
+<p>To <dfn export>isomorphic encode</dfn> a <a>string</a> <var>input</var>, run these steps:</p>
 
 <ol>
  <li><p>Assert: <var>input</var> contains no code points greater than U+00FF.
@@ -468,9 +464,6 @@ run these steps:</p>
  <var>input</var>'s <a for=string>length</a> and whose bytes have the same values as
  <var>input</var>'s code points, in the same order.
 </ol>
-
-<p class=note>This matches the behavior of a ISO-8859-1 encoder, except no such encoder is defined
-as the Encoding Standard maps "<code>iso-8859-1</code>" to <a>windows-1252</a>. [[ENCODING]]
 
 <hr>
 

--- a/infra.bs
+++ b/infra.bs
@@ -297,8 +297,9 @@ confusion with an actual <a>string</a>.
  <p>Headers, such as `<code>Content-Type</code>`, are <a>byte sequences</a>.
 </div>
 
-<p class=note>To get a <a>byte sequence</a> out of a <a>string</a>, use an operation such as
-<a>UTF-8 encode</a> from the Encoding Standard. [[ENCODING]]
+<p class=note>To get a <a>byte sequence</a> out of a <a>string</a>, using <a>UTF-8 encode</a> from
+the Encoding Standard is encouraged. In rare circumstances <a>isomorphic encode</a> might be needed.
+[[ENCODING]]
 
 <p>A <a>byte sequence</a>'s <dfn export for="byte sequence">length</dfn> is the number of
 <a>bytes</a> it contains.

--- a/infra.bs
+++ b/infra.bs
@@ -315,8 +315,8 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 
 <p>To <dfn export>isomorphic decode</dfn> a <a>byte sequence</a> <var>input</var>, return a
 <a>string</a> whose <a for=string>length</a> is equal to <var>input</var>'s
-<a for="byte sequence">length</a> and whose code points have the same values as <var>input</var>'s
-bytes, in the same order.
+<a for="byte sequence">length</a> and whose <a>code points</a> have the same values as
+<var>input</var>'s <a>bytes</a>, in the same order.
 
 <h3 id=code-points>Code points</h3>
 
@@ -458,11 +458,11 @@ implementations of just <a>JavaScript strings</a> for performance and memory rea
 <p>To <dfn export>isomorphic encode</dfn> a <a>string</a> <var>input</var>, run these steps:</p>
 
 <ol>
- <li><p>Assert: <var>input</var> contains no code points greater than U+00FF.
+ <li><p>Assert: <var>input</var> contains no <a>code points</a> greater than U+00FF.
 
- <li><p>Return a byte sequence whose <a for="byte sequence">length</a> is equal to
- <var>input</var>'s <a for=string>length</a> and whose bytes have the same values as
- <var>input</var>'s code points, in the same order.
+ <li><p>Return a <a>byte sequence</a> whose <a for="byte sequence">length</a> is equal to
+ <var>input</var>'s <a for=string>length</a> and whose <a>bytes</a> have the same values as
+ <var>input</var>'s <a>code points</a>, in the same order.
 </ol>
 
 <hr>

--- a/infra.bs
+++ b/infra.bs
@@ -313,6 +313,14 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 <a>byte sequence</a> <var>B</var>, if the <a>byte-lowercase</a> of <var>A</var> is the
 <a>byte-lowercase</a> of <var>B</var>.
 
+<p>To <dfn export for="byte sequence">map</dfn> a <a>byte sequence</a> <var>input</var> to a
+<a>string</a>, return a string whose <a for=string>length</a> is equal to <var>input</var>'s
+<a for="byte sequence">length</a> and whose code points have the same values as <var>input</var>'s
+bytes, in the same order.
+
+<p class=note>This matches the behavior of a ISO-8859-1 decoder, except no such decoder is defined
+as the Encoding Standard maps "iso-8859-1" to <a>windows-1252</a>. [[ENCODING]]
+
 <h3 id=code-points>Code points</h3>
 
 <p>A <dfn export lt="code point|character">code point</dfn> is a Unicode code point and is
@@ -447,6 +455,22 @@ performed.
 actually ends up representing <a lt="JavaScript string">JavaScript</a> and
 <a>scalar value strings</a>. It is even fairly typical for implementations to have multiple
 implementations of just <a>JavaScript strings</a> for performance and memory reasons.
+
+<hr>
+
+<p>To <dfn export for=string>map</dfn> a <a>string</a> <var>input</var> to a <a>byte sequence</a>,
+run these steps:</p>
+
+<ol>
+ <li><p>Assert: <var>input</var> contains no code points greater than U+00FF.
+
+ <li><p>Return a byte sequence whose <a for="byte sequence">length</a> is equal to
+ <var>input</var>'s <a for=string>length</a> and whose bytes have the same values as
+ <var>input</var>'s code points, in the same order.
+</ol>
+
+<p class=note>This matches the behavior of a ISO-8859-1 encoder, except no such encoder is defined
+as the Encoding Standard maps "iso-8859-1" to <a>windows-1252</a>. [[ENCODING]]
 
 <hr>
 

--- a/infra.bs
+++ b/infra.bs
@@ -319,7 +319,7 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 bytes, in the same order.
 
 <p class=note>This matches the behavior of a ISO-8859-1 decoder, except no such decoder is defined
-as the Encoding Standard maps "iso-8859-1" to <a>windows-1252</a>. [[ENCODING]]
+as the Encoding Standard maps "<code>iso-8859-1</code>" to <a>windows-1252</a>. [[ENCODING]]
 
 <h3 id=code-points>Code points</h3>
 
@@ -470,7 +470,7 @@ run these steps:</p>
 </ol>
 
 <p class=note>This matches the behavior of a ISO-8859-1 encoder, except no such encoder is defined
-as the Encoding Standard maps "iso-8859-1" to <a>windows-1252</a>. [[ENCODING]]
+as the Encoding Standard maps "<code>iso-8859-1</code>" to <a>windows-1252</a>. [[ENCODING]]
 
 <hr>
 


### PR DESCRIPTION
This would improve https://github.com/whatwg/fetch/pull/579 and is also needed to properly define ByteString in IDL. There might be a few other places that can use it. This also makes polymorphic algorithms less needed as we just map back and forth.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/annevk/byte-sequence-string/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/d28f5cd...9570220.html)