### PR TITLE
base64: move code point check back down

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -907,17 +907,6 @@ certain inputs.
  <!-- https://lists.w3.org/Archives/Public/public-whatwg-archive/2011May/0207.html -->
 
  <li>
-  <p>If <var>data</var> contains a <a>code point</a> that is not one of
-
-  <ul class="brief">
-   <li>U+002B (+)
-   <li>U+002F (/)
-   <li><a>ASCII alphanumeric</a>
-  </ul>
-
-  <p>then return failure.
-
- <li>
   <p>If <var>data</var>'s <a for=string>length</a> divides by 4 leaving no remainder, then:
 
   <ol>
@@ -927,6 +916,17 @@ certain inputs.
 
  <li><p>If <var>data</var>'s <a for=string>length</a> divides by 4 leaving a remainder of 1, then
  return failure.
+
+ <li>
+  <p>If <var>data</var> contains a <a>code point</a> that is not one of
+
+  <ul class="brief">
+   <li>U+002B (+)
+   <li>U+002F (/)
+   <li><a>ASCII alphanumeric</a>
+  </ul>
+
+  <p>then return failure.
 
  <li><p>Let <var>output</var> be an empty <a>byte sequence</a>.
 


### PR DESCRIPTION
I moved this step and did not realize it actually alters the algorithm drastically. In particular I assumed that U+003D (=) was always a valid code point as it's just padding, but it's not.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/annevk/base64-correction/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/8d7447e...5938533.html)