### PR TITLE
Meta: update the URL for the common deploy.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: generic
 
 env:
@@ -6,7 +7,7 @@ env:
     - DEPLOY_USER="annevankesteren"
 
 script:
-  - curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh
+  - make deploy
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ remote: infra.bs
 	curl https://api.csswg.org/bikeshed/ -f -F file=@infra.bs > infra.html -F md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
 
 deploy: infra.bs
-	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh
+	curl --remote-name --fail https://raw.githubusercontent.com/whatwg/common-build/master/deploy.sh && bash ./deploy.sh


### PR DESCRIPTION
Part of https://github.com/whatwg/whatwg.org/issues/71.

Also require the dist to be Trusty.