### PR TITLE
Editorial: add note about keyword suggestion for non-normative content

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -74,13 +74,13 @@ non-normative content.
 <p class=note>This is a <a>willful violation</a> of RFC 8174, motivated by legibility and a desire
 to preserve long-standing practice in many non-IETF-published pre-RFC 8174 documents. [[RFC8174]]
 
-<p class=note>For non-normative content, "could", "might", "can", "encouraged", "discouraged",
-"strongly encouraged", and "strongly discouraged" can be used instead.
-
 <p>All of the above is applicable to both this standard and any document that uses this standard.
 Documents using this standard are encouraged to limit themselves to "must", "must not", "should",
 and "may", and to use these in their lowercase form as that is generally considered to be more
 readable.
+
+<p>For non-normative content "strongly encouraged", "strongly discouraged", "encouraged",
+"discouraged", "can", "cannot", "could", "could not", "might", and "might not" can be used instead.
 
 
 <h3 id=other-specs>Compliance with other specifications</h3>

--- a/infra.bs
+++ b/infra.bs
@@ -74,6 +74,9 @@ non-normative content.
 <p class=note>This is a <a>willful violation</a> of RFC 8174, motivated by legibility and a desire
 to preserve long-standing practice in many non-IETF-published pre-RFC 8174 documents. [[RFC8174]]
 
+<p class=note>For non-normative content, "could", "might", "can", "encouraged", "discouraged",
+"strongly encouraged", and "strongly discouraged" can be used instead.
+
 <p>All of the above is applicable to both this standard and any document that uses this standard.
 Documents using this standard are encouraged to limit themselves to "must", "must not", "should",
 and "may", and to use these in their lowercase form as that is generally considered to be more


### PR DESCRIPTION
This struck me as being useful to editors.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tobie/infra/informative.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/6509cfb...tobie:a4582f3.html)