### PR TITLE
Restrict variables to be declared once per algorithm

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -157,7 +157,8 @@ over.
 
 <h3 id=variables>Variables</h3>
 
-<p>A variable is declared with "let" and changed with "set".
+<p>A variable must be declared with "let" and must be changed with "set". A variable must not be
+declared more than once per algorithm.
 
 <p class=example id=example-variable>Let |list| be a new <a>list</a>.</p>
 

--- a/infra.bs
+++ b/infra.bs
@@ -157,8 +157,7 @@ over.
 
 <h3 id=variables>Variables</h3>
 
-<p>A variable must be declared with "let" and must be changed with "set". A variable must not be
-declared more than once per algorithm.
+<p>A variable is declared with "let" and changed with "set".
 
 <p class=example id=example-variable>Let |list| be a new <a>list</a>.</p>
 
@@ -176,6 +175,7 @@ declared more than once per algorithm.
 
 <p>Variables must not be used before they are declared. Variables are
 <a href=https://en.wikipedia.org/wiki/Scope_(computer_science)#Block_scope>block scoped</a>.
+Variables must not be declared more than once per algorithm.
 
 
 <h3 id=algorithm-control-flow>Control flow</h3>


### PR DESCRIPTION
Fixes #141.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whatwg/infra/pull/173.html" title="Last updated on Nov 28, 2017, 5:13 PM GMT">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/whatwg/infra/aeadb8b...002bf82.html" title="Last updated on Nov 28, 2017, 5:13 PM GMT">Diff</a>