### PR TITLE
Editorial: link items in empty list definition

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -701,7 +701,7 @@ to remove all items from the list that match a given condition, or do nothing if
 </div>
 
 <p>To <dfn export for=list,stack,queue,set>empty</dfn> a <a>list</a> is to <a for=list>remove</a>
-all of its items.
+all of its <a for=list>items</a>.
 
 <p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain|exist>contains</dfn> an
 <a for=list>item</a> if it appears in the list. We can also denote this by saying that, for a
@@ -1037,6 +1037,7 @@ certain inputs.
 <p>Many thanks to
 Addison Phillips,
 Aryeh Gregor,
+Chris Rebert,
 Dominic Farolino,
 Jake Archibald,
 Jungkee Song,


### PR DESCRIPTION
Fixes #124.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://infra.spec.whatwg.org/branch-snapshots/annevk/a-items/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/infra/aeadb8b...27dc165.html)