### PR TITLE
Declare a variable using a ternary construct

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -173,6 +173,9 @@ over.
  </ol>
 </div>
 
+<p class=example id=example-variable-ternary>Let |activationTarget| be |target|, if
+|isActivationEvent| is true and target has activation behavior, and null otherwise.
+
 <p>Variables must not be used before they are declared. Variables are
 <a href=https://en.wikipedia.org/wiki/Scope_(computer_science)#Block_scope>block scoped</a>.
 


### PR DESCRIPTION
Fixes #157.