### PR TITLE
Define multimap

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -922,13 +922,20 @@ in consecutively increasing order, as long as <var>m</var> is greather than or e
 
 <h3 id=maps>Maps</h3>
 
-<p>An <dfn export lt="ordered map|map">ordered map</dfn>, or sometimes just "map", is a
+<p>An <dfn export lt="ordered multimap|multimap">ordered multimap</dfn>, or sometimes just "multimap", is a
 specification type consisting of a finite ordered sequence of
-<dfn for=map export>key</dfn>/<dfn for=map export>value</dfn> pairs, with no key appearing twice.
+<dfn for=map export>key</dfn>/<dfn for=map export>value</dfn> pairs, with no requirement for key uniqueness, 
+nore that all equal keys appear together in the sequence.
 Each key/value pair is called an <dfn for=map export>entry</dfn>.
 
-<p class=note>As with <a>ordered sets</a>, by default we assume that maps need to be ordered for
-interoperability among implementations.
+<p>An <dfn export lt="ordered map|map">ordered map</dfn>, or sometimes just "map", is a
+specification type consisting of a finite ordered sequence of
+<a>key</a>/<a>value</a> pairs, with no key appearing twice.
+Each key/value pair is called an <a>entry</a>.  Conceptually, an <a>ordered map</a> is a 
+subtype of <a>ordered multimap</a> with an added uniqueness constraint.
+
+<p class=note>As with <a>ordered sets</a>, by default we assume that multimaps and maps need
+to be ordered for interoperability among implementations.
 
 <p>A literal syntax can be used to express <a>ordered maps</a>, by surrounding the ordered map with
 «[ ]» characters, denoting each of its <a for=map>entries</a> as |key| → |value|, and separating its

--- a/infra.bs
+++ b/infra.bs
@@ -922,12 +922,6 @@ in consecutively increasing order, as long as <var>m</var> is greather than or e
 
 <h3 id=maps>Maps</h3>
 
-<p>An <dfn export lt="ordered multimap|multimap">ordered multimap</dfn>, or sometimes just "multimap", is a
-specification type consisting of a finite ordered sequence of
-<dfn for=map export>key</dfn>/<dfn for=map export>value</dfn> pairs, with no requirement for key uniqueness, 
-nore that all equal keys appear together in the sequence.
-Each key/value pair is called an <dfn for=map export>entry</dfn>.
-
 <p>An <dfn export lt="ordered map|map">ordered map</dfn>, or sometimes just "map", is a
 specification type consisting of a finite ordered sequence of
 <a>key</a>/<a>value</a> pairs, with no key appearing twice.
@@ -989,6 +983,14 @@ a set of steps on each <a for=map>entry</a> in order, use phrasing of the form
 "<a for=map>For each</a> |key| → |value| of |map|", and then operate on |key| and |value| in the
 subsequent prose.
 
+<h4 id=structs>Multimaps</h3>
+
+<p>An <dfn export lt="ordered multimap|multimap">ordered multimap</dfn>, or sometimes just "multimap", is a
+specification type consisting of a finite ordered sequence of
+<dfn for=map export>key</dfn>/<dfn for=map export>value</dfn> pairs, with no requirement for key uniqueness, 
+nor that all equal keys appear together in the sequence.
+Each key/value pair is called an <dfn for=map export>entry</dfn>.   This specification does not currently 
+define generic operations on a multimap.
 
 <h3 id=structs>Structs</h3>
 


### PR DESCRIPTION
Add term ordered multimap. 

Adjust language in definition of ordered map.

Fixes: #198


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/199.html" title="Last updated on May 7, 2018, 11:15 PM GMT (c0e7fcd)">Preview</a> | <a href="https://whatpr.org/infra/199/23ce6ea...c0e7fcd.html" title="Last updated on May 7, 2018, 11:15 PM GMT (c0e7fcd)">Diff</a>