### PR TITLE
For-of rather than for-in

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -285,7 +285,7 @@ iteration.
 
  <ol>
   <li>
-   <p><a for=list>For each</a> |item| in |example|:
+   <p><a for=list>For each</a> |item| of |example|:
    <ol>
     <li>Perform |operation| on |item|.
    </ol>
@@ -296,7 +296,7 @@ iteration.
 
  <ol>
   <li>
-   <p><a for=list>For each</a> |item| in |example|:
+   <p><a for=list>For each</a> |item| of |example|:
    <ol>
     <li>If |item| is 3, then <a for=iteration>continue</a>.
     <li>Perform |operation| on |item|.
@@ -308,7 +308,7 @@ iteration.
 
  <ol>
   <li>
-   <p><a for=list>For each</a> |item| in |example|:
+   <p><a for=list>For each</a> |item| of |example|:
    <ol>
     <li>If |item| is 3, then <a for=iteration>break</a>.
     <li>Perform |operation| on |item|.
@@ -916,7 +916,7 @@ of creating a new <a>ordered set</a> |set| and, <a for=list>for each</a> |item| 
 in consecutively increasing order, as long as <var>m</var> is greather than or equal to
 <var>n</var>.
 
-<p class=example id=example-the-range><a for=set>For each</a> <var>n</var> in <a>the range</a> 1 to
+<p class=example id=example-the-range><a for=set>For each</a> <var>n</var> of <a>the range</a> 1 to
 4, inclusive, &hellip;
 
 


### PR DESCRIPTION
"of" seems to be used in the normative spec, whereas a few examples used "in".