### PR TITLE
Add ASCII encode and decode algorithms.

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -569,6 +569,18 @@ the <a>string</a> with their corresponding <a>code point</a> in <a>ASCII upper a
 <a>ASCII lowercase</a> of <var>B</var>.
 <!-- TODO: define string equals? -->
 
+<p>To <dfn export>ASCII encode</dfn> a <a>string</a> <var>input</var>, run these steps:</p>
+
+<ol>
+ <li><p><a>Assert</a>: <var>input</var> is an <a>ASCII string</a>.
+
+ <p class=note>Note: This precondition ensures that <a>isomorphic encode</a> and
+ <a>utf-8 encode</a> return the same <a>byte sequence</a> for this input.
+
+ <li><p>Return the <a>isomorphic encoding</a> of <var>input</var>.
+</ol>
+
+
 <hr>
 
 <p>To <dfn export>strip newlines</dfn> from a <a>string</a>, remove any U+000A LF and U+000D CR

--- a/infra.bs
+++ b/infra.bs
@@ -569,24 +569,24 @@ the <a>string</a> with their corresponding <a>code point</a> in <a>ASCII upper a
 <a>ASCII lowercase</a> of <var>B</var>.
 <!-- TODO: define string equals? -->
 
-<p>To <dfn export>ASCII encode</dfn> a <a>string</a> <var>input</var>, run these steps:</p>
+<p>To <dfn export>ASCII encode</dfn> a <a>string</a> <var>input</var>, run these steps:
 
 <ol>
  <li><p><a>Assert</a>: <var>input</var> is an <a>ASCII string</a>.
 
  <p class=note>Note: This precondition ensures that <a>isomorphic encode</a> and
- <a>utf-8 encode</a> return the same <a>byte sequence</a> for this input.
+ <a>UTF-8 encode</a> return the same <a>byte sequence</a> for this input.
 
  <li><p>Return the <a>isomorphic encoding</a> of <var>input</var>.
 </ol>
 
-<p>To <dfn export>ASCII decode</dfn> a <a>byte sequence</a> <var>input</var>, run these steps:</p>
+<p>To <dfn export>ASCII decode</dfn> a <a>byte sequence</a> <var>input</var>, run these steps:
 
 <ol>
  <li><p><a>Assert</a>: All bytes in <var>input</var> are <a>ASCII bytes</a>.
 
  <p class=note>Note: This precondition ensures that <a>isomorphic decode</a> and
- <a>utf-8 decode</a> return the same <a>string</a> for this input.
+ <a>UTF-8 decode</a> return the same <a>string</a> for this input.
 
  <li><p>Return the <a>isomorphic decoding</a> of <var>input</var>.
 </ol>

--- a/infra.bs
+++ b/infra.bs
@@ -580,6 +580,17 @@ the <a>string</a> with their corresponding <a>code point</a> in <a>ASCII upper a
  <li><p>Return the <a>isomorphic encoding</a> of <var>input</var>.
 </ol>
 
+<p>To <dfn export>ASCII decode</dfn> a <a>byte sequence</a> <var>input</var>, run these steps:</p>
+
+<ol>
+ <li><p><a>Assert</a>: All bytes in <var>input</var> are <a>ASCII bytes</a>.
+
+ <p class=note>Note: This precondition ensures that <a>isomorphic decode</a> and
+ <a>utf-8 decode</a> return the same <a>string</a> for this input.
+
+ <li><p>Return the <a>isomorphic decoding</a> of <var>input</var>.
+</ol>
+
 
 <hr>
 


### PR DESCRIPTION
This isn't that important, but in case you want it:

I'm using this with
https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2,
which returns strings in some cases that I'd like to use them as byte
sequences. Because of
https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.7,
I'm guaranteed they're actually all ASCII.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/209.html" title="Last updated on Jul 30, 2018, 5:44 PM GMT (9232e78)">Preview</a> | <a href="https://whatpr.org/infra/209/49cfbc0...9232e78.html" title="Last updated on Jul 30, 2018, 5:44 PM GMT (9232e78)">Diff</a>