### PR TITLE
Add "normalize newlines to LF"

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -598,6 +598,10 @@ the <a>string</a> with their corresponding <a>code point</a> in <a>ASCII upper a
 <p>To <dfn export>strip newlines</dfn> from a <a>string</a>, remove any U+000A LF and U+000D CR
 <a>code points</a> from the <a>string</a>.
 
+<p>To <dfn export>normalize newlines to LF</dfn> in a <a>string</a>, replace every U+000D CR U+000A
+LF <a>code point</a> pair with a single U+000A LF <a>code point</a>, and then replace every
+remaining U+000D CR <a>code point</a> with a U+000A LF <a>code point</a>.
+
 <p>To <dfn export>strip leading and trailing ASCII whitespace</dfn> from a <a>string</a>, remove all
 <a>ASCII whitespace</a> that are at the start or the end of the <a>string</a>.
 

--- a/infra.bs
+++ b/infra.bs
@@ -598,9 +598,9 @@ the <a>string</a> with their corresponding <a>code point</a> in <a>ASCII upper a
 <p>To <dfn export>strip newlines</dfn> from a <a>string</a>, remove any U+000A LF and U+000D CR
 <a>code points</a> from the <a>string</a>.
 
-<p>To <dfn export>normalize newlines to LF</dfn> in a <a>string</a>, replace every U+000D CR U+000A
-LF <a>code point</a> pair with a single U+000A LF <a>code point</a>, and then replace every
-remaining U+000D CR <a>code point</a> with a U+000A LF <a>code point</a>.
+<p>To <dfn export>normalize newlines</dfn> in a <a>string</a>, replace every U+000D CR U+000A LF
+<a>code point</a> pair with a single U+000A LF <a>code point</a>, and then replace every remaining
+U+000D CR <a>code point</a> with a U+000A LF <a>code point</a>.
 
 <p>To <dfn export>strip leading and trailing ASCII whitespace</dfn> from a <a>string</a>, remove all
 <a>ASCII whitespace</a> that are at the start or the end of the <a>string</a>.


### PR DESCRIPTION
This will help with https://github.com/whatwg/html/pull/4105, and can also replace or help with several other similar operations throughout various specifications.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/221.html" title="Last updated on Oct 19, 2018, 9:05 AM GMT (3d406f2)">Preview</a> | <a href="https://whatpr.org/infra/221/dbb1e17...3d406f2.html" title="Last updated on Oct 19, 2018, 9:05 AM GMT (3d406f2)">Diff</a>