### PR TITLE
Add flat append

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -802,10 +802,18 @@ add the given <a for=list>item</a> to the end of the list.
 <p>To <dfn export for=list>extend</dfn> a <a>list</a> |A| with a <a>list</a> |B|,
 <a for=list>for each</a> |item| of |B|, <a for=list>append</a> |item| to |A|.
 
-<p class=example id=example-list-extend>To <a for=list>extend</a> « "<code>Erin Gilbert</code>",
-"<code>Abby Yates</code>" » with « "<code>Jillian Holtzmann</code>", "<code>Patty Tolan</code>" »
-gives « "<code>Erin Gilbert</code>", "<code>Abby Yates</code>", "<code>Jillian Holtzmann</code>",
-"<code>Patty Tolan</code>" ».
+<div class=example id=example-list-extend>
+ <ol>
+  <li><p>Let |ghostbusters| be « "<code>Erin Gilbert</code>", "<code>Abby Yates</code>" ».
+
+  <li><p><a for=list>Extend</a> |ghostbusters| with « "<code>Jillian Holtzmann</code>",
+  "<code>Patty Tolan</code>" ».
+
+  <li><p><a>Assert</a>: |ghostbusters|'s <a for=list>size</a> is 4.
+
+  <li><p><a>Assert</a>: |ghostbusters|[2] is "<code>Jillian Holtzmann</code>".
+ </ol>
+</div>
 
 <p>To <dfn export for=list>prepend</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
 add the given <a for=list>item</a> to the beginning of the list.

--- a/infra.bs
+++ b/infra.bs
@@ -799,6 +799,9 @@ out-of-bounds, except when used with <a for=list>exists</a>.
 <p>To <dfn export for=list>append</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
 add the given <a for=list>item</a> to the end of the list.
 
+<p>To <dfn export for=list>flat append</dfn> a <a>list</a> |A| to a <a>list</a> |B|,
+<a for=list>for each</a> |item| of |A|, <a for=list>append</a> |item| to |B|.
+
 <p>To <dfn export for=list>prepend</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
 add the given <a for=list>item</a> to the beginning of the list.
 

--- a/infra.bs
+++ b/infra.bs
@@ -799,8 +799,13 @@ out-of-bounds, except when used with <a for=list>exists</a>.
 <p>To <dfn export for=list>append</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
 add the given <a for=list>item</a> to the end of the list.
 
-<p>To <dfn export for=list>flat append</dfn> a <a>list</a> |A| to a <a>list</a> |B|,
-<a for=list>for each</a> |item| of |A|, <a for=list>append</a> |item| to |B|.
+<p>To <dfn export for=list>extend</dfn> a <a>list</a> |A| with a <a>list</a> |B|,
+<a for=list>for each</a> |item| of |B|, <a for=list>append</a> |item| to |A|.
+
+<p class=example id=example-list-extend>To <a for=list>extend</a> « "<code>Erin Gilbert</code>",
+"<code>Abby Yates</code>" » with « "<code>Jillian Holtzmann</code>", "<code>Patty Tolan</code>" »
+gives « "<code>Erin Gilbert</code>", "<code>Abby Yates</code>", "<code>Jillian Holtzmann</code>",
+"<code>Patty Tolan</code>" ».
 
 <p>To <dfn export for=list>prepend</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
 add the given <a for=list>item</a> to the beginning of the list.


### PR DESCRIPTION
To insert the items of the first given list at the end of the second given list.

Fixes #238.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/241.html" title="Last updated on Mar 29, 2019, 8:42 AM UTC (bc36ef4)">Preview</a> | <a href="https://whatpr.org/infra/241/b49b463...bc36ef4.html" title="Last updated on Mar 29, 2019, 8:42 AM UTC (bc36ef4)">Diff</a>