### PR TITLE
Add "parse JSON into maps and lists"

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1216,8 +1216,7 @@ the involved objects or arrays are tied to a particular <a lt="realm">JavaScript
 standards, it is often more convenient to parse JSON into realm-independent <a>maps</a>,
 <a>lists</a>, <a>strings</a>, <a>booleans</a>, numbers, and nulls.
 
-<p>To <dfn export>parse JSON into maps and lists</dfn>, given a <a>string</a>
-<var>jsonText</var>:
+<p>To <dfn export>parse JSON into Infra values</dfn>, given a <a>string</a> <var>jsonText</var>:
 
 <ol>
  <li><p>Let |jsValue| be ? [$Call$](<a>%JSONParse%</a>, undefined, « |jsonText| »).
@@ -1276,6 +1275,7 @@ given a JavaScript value <var>jsValue</var>:
 
  <li><p>Return |result|.
 </ol>
+
 
 <h2 id=forgiving-base64>Forgiving base64</h2>
 

--- a/infra.bs
+++ b/infra.bs
@@ -14,8 +14,8 @@ urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMA-262;
         text: %JSONStringify%; url: sec-json.stringify
         text: List; url: sec-list-and-record-specification-type
         text: The String Type; url: sec-ecmascript-language-types-string-type
-    type: method; for: Array; text: sort(); url: sec-array.prototype.sort
         text: realm; url: realm
+    type: method; for: Array; text: sort(); url: sec-array.prototype.sort
     type: abstract-op;
         text: Call; url: sec-call
         text: Get; url: sec-get-o-p

--- a/infra.bs
+++ b/infra.bs
@@ -14,8 +14,15 @@ urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMA-262;
         text: %JSONStringify%; url: sec-json.stringify
         text: List; url: sec-list-and-record-specification-type
         text: The String Type; url: sec-ecmascript-language-types-string-type
-    type: abstract-op; text: Call; url: sec-call
     type: method; for: Array; text: sort(); url: sec-array.prototype.sort
+        text: realm; url: realm
+    type: abstract-op;
+        text: Call; url: sec-call
+        text: Get; url: sec-get-o-p
+        text: IsArray; url: sec-isarray
+        text: ToLength; url: sec-tolength
+        text: ToString; url: sec-tostring
+        text: Type; url: sec-ecmascript-data-types-and-values
 </pre>
 
 
@@ -1176,18 +1183,16 @@ as 200/`<code>OK</code>`.
 
 <h2 id=json>JSON</h2>
 
+<p class=note>The conventions used in the algorithms in this section are those of the JavaScript
+specification. [[!ECMA-262]]
+
 <p>To <dfn export>parse JSON from bytes</dfn> given <var>bytes</var>, run these steps:
 
 <ol>
  <li><p>Let <var>jsonText</var> be the result of running <a>UTF-8 decode</a> on <var>bytes</var>.
  [[!ENCODING]]
 
- <li>
-  <p>Return ? <a abstract-op>Call</a>(<a>%JSONParse%</a>, undefined, « <var>jsonText</var> »).
-  [[!ECMA-262]]
-
-  <p class=note>The conventions used in this step are those of the JavaScript specification.
-
+ <li><p>Return ? <a abstract-op>Call</a>(<a>%JSONParse%</a>, undefined, « <var>jsonText</var> »).
 </ol>
 
 <p>To <dfn export>serialize JSON to bytes</dfn> a given JavaScript value <var>value</var>, run these
@@ -1195,16 +1200,82 @@ steps:
 
 <ol>
  <li>
-  <p>Let <var>jsonString</var> be the result of
+  <p>Let <var>jsonString</var> be
   ? <a abstract-op>Call</a>(<a>%JSONStringify%</a>, undefined, « <var>value</var> »).
-  [[!ECMA-262]]
-  <p class=note>The conventions used in this step are those of the JavaScript specification.
-    Also, since no additional arguments are passed to <a>%JSONStringify%</a>, the resulting string
-    will have no whitespace inserted.
+
+  <p class=note>Since no additional arguments are passed to <a>%JSONStringify%</a>, the resulting
+  string will have no whitespace inserted.
 
  <li><p>Return the result of running <a>UTF-8 encode</a> on <var>jsonString</var>. [[!ENCODING]]
 </ol>
 
+<hr>
+
+<p>The above two operations operate on JavaScript values directly; in particular, this means that
+the involved objects or arrays are tied to a particular <a lt="realm">JavaScript realm</a>. In
+standards, it is often more convenient to parse JSON into realm-independent <a>maps</a>,
+<a>lists</a>, <a>strings</a>, <a>booleans</a>, numbers, and nulls.
+
+<p>To <dfn export>parse JSON into maps and lists</dfn>, given a <a>string</a>
+<var>jsonText</var>:
+
+<ol>
+ <li><p>Let |jsValue| be ? [$Call$](<a>%JSONParse%</a>, undefined, « |jsonText| »).
+
+ <li><p>Return the result of [=converting a JSON-derived JavaScript value to an Infra value=], given
+ |jsValue|.
+</ol>
+
+<p>To <dfn lt="convert a JSON-derived JavaScript value to an Infra value|converting a JSON-derived JavaScript value to an Infra value">convert a JSON-derived JavaScript value to an Infra value</dfn>,
+given a JavaScript value <var>jsValue</var>:
+
+<ol>
+ <li><p>If [$Type$](|jsValue|) is Null, String, or Number, then return |jsValue|.
+
+ <li>
+  <p>If [$IsArray$](|jsValue|) is true, then:
+
+   <ol>
+    <li><p>Let |result| be an empty [=list=].
+
+    <li><p>Let |length| be ! [$ToLength$](! [$Get$](|jsValue|, "<code>length</code>")).
+
+    <li>
+      <p>[=list/For each=] |index| of [=the range=] 0 to |length| &minus; 1, inclusive:
+
+      <ol>
+       <li><p>Let |indexName| be ! [$ToString$](|index|).
+
+       <li><p>Let |jsValueAtIndex| be ! [$Get$](|jsValue|, |indexName|).
+
+       <li><p>Let |infraValueAtIndex| be the result of [=converting a JSON-derived JavaScript value to an Infra value=],
+       given |jsValueAtIndex|.
+
+       <li><p>[=list/Append=] |infraValueAtIndex| to |result|.
+      </ol>
+    </li>
+
+    <li><p>Return |result|.
+   </ol>
+ </li>
+
+ <li><p>Let |result| be an empty [=ordered map=].
+
+ <li>
+  <p>[=list/For each=] |key| of ! |jsValue|.\[[OwnPropertyKeys]]():
+
+   <ol>
+    <li><p>Let |jsValueAtKey| be ! [$Get$](|jsValue|, |key|).
+
+    <li><p>Let |infraValueAtKey| be the result of [=converting a JSON-derived JavaScript value to an Infra value=],
+    given |jsValueAtKey|.
+
+    <li><p>[=map/Set=] |result|[|key|] to |infraValueAtKey|.
+   </ol>
+ </li>
+
+ <li><p>Return |result|.
+</ol>
 
 <h2 id=forgiving-base64>Forgiving base64</h2>
 


### PR DESCRIPTION
Part of #159. This provides the basic parsing framework, although no validation or type-checking.

Questions:

- Is this name reasonable?
- Should we take bytes or a string as input? Offer both variants? For import maps I need a string input, so I want that available at least... But it's a bit asymmetric with the byte-accepting variant previous.

Comment for @annevk: I used Bikeshed shorthands here because I find them way more pleasant than all the close and open tags for `<a>` and `<var>`. I was tempted to use Bikeshed's built-in list and paragraph support as well, but I refrained. I realize this is inconsistent with the rest of the source text, and will change it if you so desire. I just urge you to look at the beauty that is the source of [the import maps spec](https://github.com/WICG/import-maps/blob/2f8d0fcd5becd4e6398c80530f5224fdc1d93511/spec.bs) and consider what could be :).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/249.html" title="Last updated on May 10, 2019, 3:43 PM UTC (2739ae5)">Preview</a> | <a href="https://whatpr.org/infra/249/b522298...2739ae5.html" title="Last updated on May 10, 2019, 3:43 PM UTC (2739ae5)">Diff</a>