### PR TITLE
Add cloning for maps

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -982,7 +982,8 @@ subsequent prose.
 <a for=list>append</a> |item| to |clone|, so that |clone| <a for=list>contains</a> the same
 <a for=list>items</a>, in the same order as |list|.
 
-<p class=note>This is a "shallow clone", as the <a for=list>items</a> themselves are not cloned in any way.
+<p class=note>This is a "shallow clone", as the <a for=list>items</a> themselves are not cloned in
+any way.
 
 <p class=example id=example-list-clone>Let |original| be the <a>ordered set</a> «
 "<code>a</code>", "<code>b</code>", "<code>c</code>" ». <a for=set>Cloning</a> |original| creates
@@ -1164,9 +1165,9 @@ a set of steps on each <a for=map>entry</a> in order, use phrasing of the form
 "<a for=map>For each</a> |key| → |value| of |map|", and then operate on |key| and |value| in the
 subsequent prose.
 
-<p>To <dfn export for=map>clone</dfn> an <a>ordered map</a> |map| is to create a new <a>ordered
- map</a> |clone|, and, <a for=map>for each</a> |key| → |value| of |map|, <a for=map>set</a>
- |clone|[|key|] to |value|.
+<p>To <dfn export for=map>clone</dfn> an <a>ordered map</a> |map| is to create a new
+<a>ordered map</a> |clone|, and, <a for=map>for each</a> |key| → |value| of |map|,
+<a for=map>set</a> |clone|[|key|] to |value|.
 
 <p class=note>This is a "shallow clone", as the <a for=map>keys</a> and <a for=map>values</a>
 themselves are not cloned in any way.

--- a/infra.bs
+++ b/infra.bs
@@ -982,7 +982,7 @@ subsequent prose.
 <a for=list>append</a> |item| to |clone|, so that |clone| <a for=list>contains</a> the same
 <a for=list>items</a>, in the same order as |list|.
 
-Note: This is a "shallow clone", as the <a for=list>items</a> themselves are not cloned in any way.
+<p class=note>This is a "shallow clone", as the <a for=list>items</a> themselves are not cloned in any way.
 
 <p class=example id=example-list-clone>Let |original| be the <a>ordered set</a> «
 "<code>a</code>", "<code>b</code>", "<code>c</code>" ». <a for=set>Cloning</a> |original| creates
@@ -1163,6 +1163,21 @@ of running <a for=map>get the keys</a> on the map.
 a set of steps on each <a for=map>entry</a> in order, use phrasing of the form
 "<a for=map>For each</a> |key| → |value| of |map|", and then operate on |key| and |value| in the
 subsequent prose.
+
+<p>To <dfn export for=map>clone</dfn> an <a>ordered map</a> |map| is to create a new <a>ordered
+ map</a> |clone|, and, <a for=map>for each</a> |key| → |value| of |map|, <a for=map>set</a>
+ |clone|[|key|] to |value|.
+
+<p class=note>This is a "shallow clone", as the <a for=map>keys</a> and <a for=map>values</a>
+themselves are not cloned in any way.
+
+<p class=example id=example-map-clone>Let |original| be the <a>ordered map</a> «[
+"<code>a</code>" → «1, 2, 3», "<code>b</code>" → «» ]». <a for=set>Cloning</a> |original| creates a
+new <a>ordered map</a> |clone|, so that <a for=map>setting</a> |clone|["<code>a</code>"] to
+«-1, -2, -3» gives «[ "<code>a</code>" → «-1, -2, -3», "<code>b</code>" → «» ]» and leaves
+|original| unchanged. However, <a for=list>appending</a> 4 to |clone|["<code>b</code>"] will modify
+the corresponding <a for=map>value</a> in both |clone| and |original|, as they both point to the
+same <a>list</a>.
 
 <p>To <dfn export for=map lt="sort in ascending order|sorting in ascending order|sort|sorting">sort in ascending order</dfn>
 a <a>map</a> |map|, with a less than algorithm |lessThanAlgo|, is to create a new <a>map</a>


### PR DESCRIPTION
A need for this came up in https://github.com/WICG/import-maps/pull/167


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/265.html" title="Last updated on Aug 30, 2019, 4:54 PM UTC (49807d2)">Preview</a> | <a href="https://whatpr.org/infra/265/d890198...49807d2.html" title="Last updated on Aug 30, 2019, 4:54 PM UTC (49807d2)">Diff</a>