### PR TITLE
Change code unit-dependent algorithms to operate on JavaScript strings.

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -663,9 +663,9 @@ implementations of just <a>JavaScript strings</a> for performance and memory rea
 
 <hr>
 
-<p>A <a>string</a> <var>a</var> is a
-<dfn export lt="code unit prefix|starts with">code unit prefix</dfn> of a <a>string</a> <var>b</var>
-if the following steps return true:
+<p>A <a>JavaScript string</a> <var>a</var> is a
+<dfn export lt="code unit prefix|starts with">code unit prefix</dfn> of a <a>JavaScript string</a>
+<var>b</var> if the following steps return true:
 
 <ol>
  <li><p>Let <var>i</var> be 0.
@@ -675,10 +675,10 @@ if the following steps return true:
 
   <ol>
    <li><p>Let <var>aCodeUnit</var> be the <var>i</var>th <a>code unit</a> of <var>a</var> if
-   <var>i</var> is less than <var>a</var>'s <a for=string>length</a>; otherwise null.
+   <var>i</var> is less than <var>a</var>'s <a for="JavaScript string">length</a>; otherwise null.
 
    <li><p>Let <var>bCodeUnit</var> be the <var>i</var>th <a>code unit</a> of <var>b</var> if
-   <var>i</var> is less than <var>b</var>'s <a for=string>length</a>; otherwise null.
+   <var>i</var> is less than <var>b</var>'s <a for="JavaScript string">length</a>; otherwise null.
 
    <li><p>If <var>bCodeUnit</var> is null, then return true.
 
@@ -698,8 +698,8 @@ strings is a literal containing only characters that are in the range U+0020 SPA
 <var ignore>targetString</var> is a <a>code unit prefix</a> of <var>userInput</var>. But with a
 literal, we can use plainer language: <var>userInput</var> starts with "<code>!</code>".
 
-<p>A <a>string</a> <var>a</var> is <dfn export>code unit less than</dfn> a <a>string</a>
-<var>b</var> if the following steps return true:
+<p>A <a>JavaScript string</a> <var>a</var> is <dfn export>code unit less than</dfn> a
+<a>JavaScript string</a> <var>b</var> if the following steps return true:
 
 <ol>
  <li><p>If <var>b</var> is a <a>code unit prefix</a> of <var>a</var>, then return false.


### PR DESCRIPTION
This change updates the code unit prefix and code unit less than algorithms to operate on JavaScript strings, rather than strings, since they only operate on them as sequences of code units. Additionally, the code unit prefix algorithm mistakenly depends on the string's length in a context when it needs to measure the number of code units, which this change replaces to the JavaScript string's length.

Fixes #288.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/289.html" title="Last updated on Feb 3, 2020, 11:26 AM UTC (0d9420a)">Preview</a> | <a href="https://whatpr.org/infra/289/d3549e1...0d9420a.html" title="Last updated on Feb 3, 2020, 11:26 AM UTC (0d9420a)">Diff</a>