### PR TITLE
Fix the usage of "length" in the code unit prefix algorithm

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -675,10 +675,10 @@ if the following steps return true:
 
   <ol>
    <li><p>Let <var>aCodeUnit</var> be the <var>i</var>th <a>code unit</a> of <var>a</var> if
-   <var>i</var> is less than <var>a</var>'s <a for=string>length</a>; otherwise null.
+   <var>i</var> is less than <var>a</var>'s <a for="JavaScript string">length</a>; otherwise null.
 
    <li><p>Let <var>bCodeUnit</var> be the <var>i</var>th <a>code unit</a> of <var>b</var> if
-   <var>i</var> is less than <var>b</var>'s <a for=string>length</a>; otherwise null.
+   <var>i</var> is less than <var>b</var>'s <a for="JavaScript string">length</a>; otherwise null.
 
    <li><p>If <var>bCodeUnit</var> is null, then return true.
 
@@ -1495,6 +1495,7 @@ certain inputs.
 
 <p>Many thanks to
 Addison Phillips,
+Andreu Botella,
 Aryeh Gregor,
 Chris Rebert,
 Daniel Ehrenberg,


### PR DESCRIPTION
This change corrects the usage of "length" as applied to strings in the code unit prefix algorithm, when in context it measures the number of code units, not code points.

Fixes #288.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/290.html" title="Last updated on Feb 12, 2020, 1:24 AM UTC (41f3d7e)">Preview</a> | <a href="https://whatpr.org/infra/290/d3549e1...41f3d7e.html" title="Last updated on Feb 12, 2020, 1:24 AM UTC (41f3d7e)">Diff</a>