### PR TITLE
Redo JavaScript and scalar value strings

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -628,13 +628,13 @@ them effectively as-is.
 <a>code units</a> 0xD83D, 0xDCA9, and 0xD800, when interpreted as containing <a>code points</a>,
 would consist of the <a>code points</a> U+1F4A9 and U+D800.
 
-<p>A <a>string</a>'s <dfn export for=string>code unit length</dfn> is the number of
-<a>code units</a> it contains. For now, this can also be referred to as a <a>JavaScript string</a>'s
-<dfn export for="JavaScript string">length</dfn>.
+<p>A <a>string</a>'s
+<dfn export for="string,JavaScript string,scalar value string">length</dfn> is the number of
+<a>code units</a> it contains.
 
-<p>A <a>string</a>'s <dfn export for=string>code point length</dfn> is the number of
-<a>code points</a> it contains. For now, this can also be referred to as a <a>string</a>'s
-<dfn export for=string>length</dfn>.
+<p>A <a>string</a>'s
+<dfn export for="string,JavaScript string,scalar value string">code point length</dfn> is the number
+of <a>code points</a> it contains.
 
 <p>A <dfn export>scalar value string</dfn> is a <a>string</a> whose <a>code points</a> are all
 <a>scalar values</a>.
@@ -676,10 +676,10 @@ if the following steps return true:
 
   <ol>
    <li><p>Let <var>aCodeUnit</var> be the <var>i</var>th <a>code unit</a> of <var>a</var> if
-   <var>i</var> is less than <var>a</var>'s <a for=string>code unit length</a>; otherwise null.
+   <var>i</var> is less than <var>a</var>'s <a for=string>length</a>; otherwise null.
 
    <li><p>Let <var>bCodeUnit</var> be the <var>i</var>th <a>code unit</a> of <var>b</var> if
-   <var>i</var> is less than <var>b</var>'s <a for=string>code unit length</a>; otherwise null.
+   <var>i</var> is less than <var>b</var>'s <a for=string>length</a>; otherwise null.
 
    <li><p>If <var>bCodeUnit</var> is null, then return true.
 

--- a/infra.bs
+++ b/infra.bs
@@ -629,8 +629,8 @@ them effectively as-is.
 would consist of the <a>code points</a> U+1F4A9 and U+D800.
 
 <p>A <a>string</a>'s
-<dfn export for="string,JavaScript string,scalar value string">length</dfn> is the number of
-<a>code units</a> it contains.
+<dfn export for="string,JavaScript string,scalar value string" id="javascript-string-length">length</dfn>
+is the number of <a>code units</a> it contains.
 
 <p>A <a>string</a>'s
 <dfn export for="string,JavaScript string,scalar value string">code point length</dfn> is the number

--- a/infra.bs
+++ b/infra.bs
@@ -7,10 +7,6 @@ Abstract: The Infra Standard aims to define the fundamental concepts upon which 
 Translation: ja https://triple-underscore.github.io/infra-ja.html
 </pre>
 
-<pre class=link-defaults>
-spec:infra; type:dfn; text:string
-</pre>
-
 <pre class=anchors>
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMA-262;
     type: dfn

--- a/infra.bs
+++ b/infra.bs
@@ -7,6 +7,10 @@ Abstract: The Infra Standard aims to define the fundamental concepts upon which 
 Translation: ja https://triple-underscore.github.io/infra-ja.html
 </pre>
 
+<pre class=link-defaults>
+spec:infra; type:dfn; text:string
+</pre>
+
 <pre class=anchors>
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMA-262;
     type: dfn

--- a/infra.bs
+++ b/infra.bs
@@ -520,7 +520,7 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 <hr>
 
 <p>To <dfn export>isomorphic decode</dfn> a <a>byte sequence</a> <var>input</var>, return a
-<a>string</a> whose <a for=string>length</a> is equal to <var>input</var>'s
+<a>string</a> whose <a for=string>code point length</a> is equal to <var>input</var>'s
 <a for="byte sequence">length</a> and whose <a>code points</a> have the same values as
 <var>input</var>'s <a>bytes</a>, in the same order.
 
@@ -608,14 +608,14 @@ U+007A (z), inclusive.
 
 <h3 id=strings>Strings</h3>
 
-<p>A <dfn export>JavaScript string</dfn> is a sequence of unsigned 16-bit integers, also known as
-<dfn export lt="code unit">code units</dfn>.
+<p>A <dfn export>string</dfn> is a sequence of unsigned 16-bit integers, also known as
+<dfn export lt="code unit">code units</dfn>. A <a>string</a> is also known as a
+<dfn export>JavaScript string</dfn>. <a>Strings</a> are denoted by double quotes and monospace font.
+
+<p class=example id=example-string-notation>"<code>Hello, world!</code>" is a string.
 
 <p class=note>This is different from how the Unicode Standard defines "code unit". In particular it
 refers exclusively to how the Unicode Standard defines it for Unicode 16-bit strings. [[UNICODE]]
-
-<p>A <a>JavaScript string</a>'s <dfn export for="JavaScript string">length</dfn> is the number of
-<a>code units</a> it contains.
 
 <p>A <a>JavaScript string</a> can also be interpreted as containing <a>code points</a>, per the
 conversion defined in <a>The String Type</a> section of the JavaScript specification. [[!ECMA-262]]
@@ -628,38 +628,40 @@ them effectively as-is.
 of the <a>code units</a> 0xD83D, 0xDCA9, and 0xD800, when interpreted as containing
 <a>code points</a>, would consist of the <a>code points</a> U+1F4A9 and U+D800.
 
-<p>A <dfn export>scalar value string</dfn> is a sequence of <a>scalar values</a>.
+<p>A <a>string</a>'s <dfn export for=string>code unit length</dfn> is the number of
+<a>code units</a> it contains. For now, this can also be referred to as a <a>JavaScript string</a>'s
+<dfn export for="JavaScript string">length</dfn>.
+
+<p>A <a>string</a>'s <dfn export for=string>code point length</dfn> is the number of
+<a>code points</a> it contains. For now, this can also be referred to as a <a>string</a>'s
+<dfn export for=string>length</dfn>.
+
+<p>A <dfn export>scalar value string</dfn> is <a>string</a> whose <a>code points</a> are all
+<a>scalar values</a>.
 
 <p class=note>A <a>scalar value string</a> is useful for any kind of I/O or other kind of operation
 where <a>UTF-8 encode</a> comes into play.
 <!-- It's also useful if you can imagine the subsystem to be implemented in Rust -->
 
-<p><dfn export lt=string>String</dfn> can be used to refer to either a <a>JavaScript string</a> or
-<a>scalar value string</a>, when it is clear from the context which is meant or when the distinction
-is immaterial. <a>Strings</a> are denoted by double quotes and monospace font.
-
-<p class=example id=example-string-notation>"<code>Hello, world!</code>" is a string.
-
-<p>A <a>string</a>'s <dfn export for=string>length</dfn> is the number of <a>code points</a> it
-contains.
-
-<p>To <dfn export for="JavaScript string">convert</dfn> a <a>JavaScript string</a> into a
+<p>To <dfn export for="JavaScript string">convert</dfn> a <a>string</a> into a
 <a>scalar value string</a>, replace any <a>surrogates</a> with U+FFFD.
 <!-- Obviates need for https://heycam.github.io/webidl/#dfn-obtain-unicode -->
 
-<p class=note>The replaced surrogates are always isolated surrogates, since the process of
-interpreting the JavaScript string as containing <a>code points</a> will have converted surrogate
-pairs into <a>scalar values</a>.
+<div class=note>
+ <p>The replaced surrogates are always isolated surrogates, since the process of interpreting the
+ JavaScript string as containing <a>code points</a> will have converted surrogate pairs into
+ <a>scalar values</a>.
 
-<p>A <a>scalar value string</a> can always be used as <a>JavaScript string</a> implicitly since it
-is a subset. The reverse is only possible if the <a>JavaScript string</a> is known to not contain
-<a>surrogates</a>; otherwise a <a for="JavaScript string" lt=convert>conversion</a> must be
-performed.
+ <p>A <a>scalar value string</a> can always be used as <a>string</a> implicitly since it is a
+ subset. The reverse is only possible if the <a>JavaScript string</a> is known to not contain
+ <a>surrogates</a>; otherwise a <a for="JavaScript string" lt=convert>conversion</a> is to be
+ performed.
 
-<p class=note>An implementation likely has to perform explicit conversion, depending on how it
-actually ends up representing <a lt="JavaScript string">JavaScript</a> and
-<a>scalar value strings</a>. It is even fairly typical for implementations to have multiple
-implementations of just <a>JavaScript strings</a> for performance and memory reasons.
+ <p>An implementation likely has to perform explicit conversion, depending on how it actually ends
+ up representing <a lt="JavaScript string">JavaScript</a> and <a>scalar value strings</a>. It is
+ fairly typical for implementations to have multiple implementations of <a>JavaScript strings</a>
+ alone for performance and memory reasons.
+</div>
 
 <hr>
 
@@ -675,10 +677,10 @@ if the following steps return true:
 
   <ol>
    <li><p>Let <var>aCodeUnit</var> be the <var>i</var>th <a>code unit</a> of <var>a</var> if
-   <var>i</var> is less than <var>a</var>'s <a for="JavaScript string">length</a>; otherwise null.
+   <var>i</var> is less than <var>a</var>'s <a for=string>code unit length</a>; otherwise null.
 
    <li><p>Let <var>bCodeUnit</var> be the <var>i</var>th <a>code unit</a> of <var>b</var> if
-   <var>i</var> is less than <var>b</var>'s <a for="JavaScript string">length</a>; otherwise null.
+   <var>i</var> is less than <var>b</var>'s <a for=string>code unit length</a>; otherwise null.
 
    <li><p>If <var>bCodeUnit</var> is null, then return true.
 
@@ -730,8 +732,8 @@ ordering will not match any particular alphabet or lexicographic order, particul
  <li><p><a>Assert</a>: <var>input</var> contains no <a>code points</a> greater than U+00FF.
 
  <li><p>Return a <a>byte sequence</a> whose <a for="byte sequence">length</a> is equal to
- <var>input</var>'s <a for=string>length</a> and whose <a>bytes</a> have the same values as
- <var>input</var>'s <a>code points</a>, in the same order.
+ <var>input</var>'s <a for=string>code point length</a> and whose <a>bytes</a> have the same values
+ as <var>input</var>'s <a>code points</a>, in the same order.
 </ol>
 
 <hr>
@@ -1416,15 +1418,16 @@ certain inputs.
  <!-- https://lists.w3.org/Archives/Public/public-whatwg-archive/2011May/0207.html -->
 
  <li>
-  <p>If <var>data</var>'s <a for=string>length</a> divides by 4 leaving no remainder, then:
+  <p>If <var>data</var>'s <a for=string>code point length</a> divides by 4 leaving no remainder,
+  then:
 
   <ol>
    <li><p>If <var>data</var> ends with one or two U+003D (=) <a>code points</a>, then remove them
    from <var>data</var>.
   </ol>
 
- <li><p>If <var>data</var>'s <a for=string>length</a> divides by 4 leaving a remainder of 1, then
- return failure.
+ <li><p>If <var>data</var>'s <a for=string>code point length</a> divides by 4 leaving a remainder of
+ 1, then return failure.
 
  <li>
   <p>If <var>data</var> contains a <a>code point</a> that is not one of

--- a/infra.bs
+++ b/infra.bs
@@ -617,16 +617,16 @@ U+007A (z), inclusive.
 <p class=note>This is different from how the Unicode Standard defines "code unit". In particular it
 refers exclusively to how the Unicode Standard defines it for Unicode 16-bit strings. [[UNICODE]]
 
-<p>A <a>JavaScript string</a> can also be interpreted as containing <a>code points</a>, per the
-conversion defined in <a>The String Type</a> section of the JavaScript specification. [[!ECMA-262]]
+<p>A <a>string</a> can also be interpreted as containing <a>code points</a>, per the conversion
+defined in <a>The String Type</a> section of the JavaScript specification. [[!ECMA-262]]
 
 <p class=note>This conversion process converts surrogate pairs into their corresponding
 <a>scalar value</a> and maps isolated surrogates to their corresponding <a>code point</a>, leaving
 them effectively as-is.
 
-<p class=example id=example-javascript-string-in-code-points>A <a>JavaScript string</a> consisting
-of the <a>code units</a> 0xD83D, 0xDCA9, and 0xD800, when interpreted as containing
-<a>code points</a>, would consist of the <a>code points</a> U+1F4A9 and U+D800.
+<p class=example id=example-javascript-string-in-code-points>A <a>string</a> consisting of the
+<a>code units</a> 0xD83D, 0xDCA9, and 0xD800, when interpreted as containing <a>code points</a>,
+would consist of the <a>code points</a> U+1F4A9 and U+D800.
 
 <p>A <a>string</a>'s <dfn export for=string>code unit length</dfn> is the number of
 <a>code units</a> it contains. For now, this can also be referred to as a <a>JavaScript string</a>'s
@@ -636,7 +636,7 @@ of the <a>code units</a> 0xD83D, 0xDCA9, and 0xD800, when interpreted as contain
 <a>code points</a> it contains. For now, this can also be referred to as a <a>string</a>'s
 <dfn export for=string>length</dfn>.
 
-<p>A <dfn export>scalar value string</dfn> is <a>string</a> whose <a>code points</a> are all
+<p>A <dfn export>scalar value string</dfn> is a <a>string</a> whose <a>code points</a> are all
 <a>scalar values</a>.
 
 <p class=note>A <a>scalar value string</a> is useful for any kind of I/O or other kind of operation
@@ -649,18 +649,17 @@ where <a>UTF-8 encode</a> comes into play.
 
 <div class=note>
  <p>The replaced surrogates are always isolated surrogates, since the process of interpreting the
- JavaScript string as containing <a>code points</a> will have converted surrogate pairs into
+ string as containing <a>code points</a> will have converted surrogate pairs into
  <a>scalar values</a>.
 
- <p>A <a>scalar value string</a> can always be used as <a>string</a> implicitly since it is a
- subset. The reverse is only possible if the <a>JavaScript string</a> is known to not contain
- <a>surrogates</a>; otherwise a <a for="JavaScript string" lt=convert>conversion</a> is to be
- performed.
+ <p>A <a>scalar value string</a> can always be used as a <a>string</a> implicitly since it is a
+ subset. The reverse is only possible if the <a>string</a> is known to not contain
+ <a>surrogates</a>; otherwise a <a for=string lt=convert>conversion</a> is to be performed.
 
  <p>An implementation likely has to perform explicit conversion, depending on how it actually ends
- up representing <a lt="JavaScript string">JavaScript</a> and <a>scalar value strings</a>. It is
- fairly typical for implementations to have multiple implementations of <a>JavaScript strings</a>
- alone for performance and memory reasons.
+ up representing <a>strings</a> and <a>scalar value strings</a>. It is fairly typical for
+ implementations to have multiple implementations of <a>strings</a> alone for performance and memory
+ reasons.
 </div>
 
 <hr>

--- a/infra.bs
+++ b/infra.bs
@@ -643,7 +643,7 @@ of the <a>code units</a> 0xD83D, 0xDCA9, and 0xD800, when interpreted as contain
 where <a>UTF-8 encode</a> comes into play.
 <!-- It's also useful if you can imagine the subsystem to be implemented in Rust -->
 
-<p>To <dfn export for="JavaScript string">convert</dfn> a <a>string</a> into a
+<p>To <dfn export for="string,JavaScript string">convert</dfn> a <a>string</a> into a
 <a>scalar value string</a>, replace any <a>surrogates</a> with U+FFFD.
 <!-- Obviates need for https://heycam.github.io/webidl/#dfn-obtain-unicode -->
 

--- a/infra.bs
+++ b/infra.bs
@@ -629,7 +629,7 @@ them effectively as-is.
 would consist of the <a>code points</a> U+1F4A9 and U+D800.
 
 <p>A <a>string</a>'s
-<dfn export for="string,JavaScript string,scalar value string" id="javascript-string-length">length</dfn>
+<dfn export for="string,JavaScript string,scalar value string" id=javascript-string-length>length</dfn>
 is the number of <a>code units</a> it contains.
 
 <p>A <a>string</a>'s
@@ -643,9 +643,8 @@ of <a>code points</a> it contains.
 where <a>UTF-8 encode</a> comes into play.
 <!-- It's also useful if you can imagine the subsystem to be implemented in Rust -->
 
-<p>To <dfn export for="string,JavaScript string">convert</dfn> a <a>string</a> into a
-<a>scalar value string</a>, replace any <a>surrogates</a> with U+FFFD.
-<!-- Obviates need for https://heycam.github.io/webidl/#dfn-obtain-unicode -->
+<p>To <dfn export for="string,JavaScript string" id=javascript-string-convert>convert</dfn> a
+<a>string</a> into a <a>scalar value string</a>, replace any <a>surrogates</a> with U+FFFD.
 
 <div class=note>
  <p>The replaced surrogates are always isolated surrogates, since the process of interpreting the

--- a/infra.bs
+++ b/infra.bs
@@ -608,9 +608,10 @@ U+007A (z), inclusive.
 
 <h3 id=strings>Strings</h3>
 
-<p>A <dfn export>string</dfn> is a sequence of unsigned 16-bit integers, also known as
-<dfn export lt="code unit">code units</dfn>. A <a>string</a> is also known as a
-<dfn export>JavaScript string</dfn>. <a>Strings</a> are denoted by double quotes and monospace font.
+<p>A <dfn export lt="string,JavaScript string">string</dfn> is a sequence of unsigned 16-bit
+integers, also known as <dfn export lt="code unit">code units</dfn>. A <a>string</a> is also known
+as a <a id="javascript-string">JavaScript string</a>. <a>Strings</a> are denoted by double quotes
+and monospace font.
 
 <p class=example id=example-string-notation>"<code>Hello, world!</code>" is a string.
 
@@ -651,9 +652,10 @@ where <a>UTF-8 encode</a> comes into play.
  string as containing <a>code points</a> will have converted surrogate pairs into
  <a>scalar values</a>.
 
- <p>A <a>scalar value string</a> can always be used as a <a>string</a> implicitly since it is a
- subset. The reverse is only possible if the <a>string</a> is known to not contain
- <a>surrogates</a>; otherwise a <a for=string lt=convert>conversion</a> is to be performed.
+ <p>A <a>scalar value string</a> can always be used as a <a>string</a> implicitly since every
+ <a>scalar value string</a> is a <a>string</a>. The reverse is only possible if the <a>string</a> is
+ known to not contain <a>surrogates</a>; otherwise a <a for=string lt=convert>conversion</a> is to
+ be performed.
 
  <p>An implementation likely has to perform explicit conversion, depending on how it actually ends
  up representing <a>strings</a> and <a>scalar value strings</a>. It is fairly typical for

--- a/infra.bs
+++ b/infra.bs
@@ -1,4 +1,4 @@
-<pre class='metadata'>
+<pre class=metadata>
 Group: WHATWG
 H1: Infra
 Shortname: infra
@@ -7,7 +7,11 @@ Abstract: The Infra Standard aims to define the fundamental concepts upon which 
 Translation: ja https://triple-underscore.github.io/infra-ja.html
 </pre>
 
-<pre class="anchors">
+<pre class=link-defaults>
+spec:infra; type:dfn; text:string
+</pre>
+
+<pre class=anchors>
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMA-262;
     type: dfn
         text: %JSONParse%; url: sec-json.parse

--- a/infra.bs
+++ b/infra.bs
@@ -657,9 +657,9 @@ where <a>UTF-8 encode</a> comes into play.
  <a>scalar values</a>.
 
  <p>A <a>scalar value string</a> can always be used as a <a>string</a> implicitly since every
- <a>scalar value string</a> is a <a>string</a>. The reverse is only possible if the <a>string</a> is
- known to not contain <a>surrogates</a>; otherwise a <a for=string lt=convert>conversion</a> is to
- be performed.
+ <a>scalar value string</a> is a <a>string</a>. On the other hand, a <a>string</a> can only be
+ implicitly used as a <a>scalar value string</a> if it is known to not contain <a>surrogates</a>;
+ otherwise a <a for=string lt=convert>conversion</a> is to be performed.
 
  <p>An implementation likely has to perform explicit conversion, depending on how it actually ends
  up representing <a>strings</a> and <a>scalar value strings</a>. It is fairly typical for


### PR DESCRIPTION
This changes things a bit so there's one clear base type, called string. A scalar value string is now defined as a subset, similar to ASCII string.

A string has two different lengths, a code unit length and a code point length, and for now we keep the legacy length dfn (for JavaScript string and string) as we're not sure of all dependencies.

Fixes part of #291.

cc @andreubotella


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/292.html" title="Last updated on Mar 10, 2020, 8:57 AM UTC (b560129)">Preview</a> | <a href="https://whatpr.org/infra/292/646a05d...b560129.html" title="Last updated on Mar 10, 2020, 8:57 AM UTC (b560129)">Diff</a>