### PR TITLE
Meta: add another ID for string's length

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -633,8 +633,8 @@ them effectively as-is.
 <a>code units</a> 0xD83D, 0xDCA9, and 0xD800, when interpreted as containing <a>code points</a>,
 would consist of the <a>code points</a> U+1F4A9 and U+D800.
 
-<p id=javascript-string-length>A <a>string</a>'s
-<dfn export for="string,JavaScript string,scalar value string" id=string-length>length</dfn>
+<p>A <a>string</a>'s
+<dfn export for="string,JavaScript string,scalar value string" id=string-length oldids=javascript-string-length>length</dfn>
 is the number of <a>code units</a> it contains.
 
 <p>A <a>string</a>'s

--- a/infra.bs
+++ b/infra.bs
@@ -7,10 +7,6 @@ Abstract: The Infra Standard aims to define the fundamental concepts upon which 
 Translation: ja https://triple-underscore.github.io/infra-ja.html
 </pre>
 
-<pre class=link-defaults>
-spec:infra; type:dfn; text:string
-</pre>
-
 <pre class=anchors>
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMA-262;
     type: dfn

--- a/infra.bs
+++ b/infra.bs
@@ -633,8 +633,8 @@ them effectively as-is.
 <a>code units</a> 0xD83D, 0xDCA9, and 0xD800, when interpreted as containing <a>code points</a>,
 would consist of the <a>code points</a> U+1F4A9 and U+D800.
 
-<p>A <a>string</a>'s
-<dfn export for="string,JavaScript string,scalar value string" id=javascript-string-length>length</dfn>
+<p id=javascript-string-length>A <a>string</a>'s
+<dfn export for="string,JavaScript string,scalar value string" id=string-length>length</dfn>
 is the number of <a>code units</a> it contains.
 
 <p>A <a>string</a>'s

--- a/infra.bs
+++ b/infra.bs
@@ -612,7 +612,7 @@ U+007A (z), inclusive.
 
 <h3 id=strings>Strings</h3>
 
-<p>A <dfn export lt="string,JavaScript string">string</dfn> is a sequence of unsigned 16-bit
+<p>A <dfn export lt="string|JavaScript string">string</dfn> is a sequence of unsigned 16-bit
 integers, also known as <dfn export lt="code unit">code units</dfn>. A <a>string</a> is also known
 as a <a id="javascript-string">JavaScript string</a>. <a>Strings</a> are denoted by double quotes
 and monospace font.


### PR DESCRIPTION
An alternative here would be to use `oldids`, but I'm not sure if that adds enough benefit for the cruft it creates.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/295.html" title="Last updated on Mar 10, 2020, 1:02 PM UTC (f8dd58d)">Preview</a> | <a href="https://whatpr.org/infra/295/587f3c2...f8dd58d.html" title="Last updated on Mar 10, 2020, 1:02 PM UTC (f8dd58d)">Diff</a>