### PR TITLE
Define implementation-defined

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -97,15 +97,18 @@ violation.
 either width or height is zero"), means an inclusive "or" (implying "or both"), unless it is called
 out as being exclusive (with "but not both").
 
-<p>A <dfn export>user agent</dfn> is any software that acts on behalf of a user, for example by
-retrieving and rendering web content and facilitating end user interaction with it. In
-specifications using the Infra Standard, the user agent is generally the client software that
-implements the specification.
+<hr>
+
+<p>A <dfn export lt="user agent|implementation">user agent</dfn> is any software that acts on behalf
+of a user, for example by retrieving and rendering web content and facilitating end user interaction
+with it. In specifications using the Infra Standard, the user agent is generally the client software
+that implements the specification. <a>Implementation</a> can be used as a synonym for
+<a>user agent</a>.
 
 <p>If something is said to be <dfn export>implementation-defined</dfn>, the particulars of what is
-said to be <a>implementation-defined</a> are up to the <a>user agent</a>. In the absense of such
-language, the reverse holds. I.e., <a>user agents</a> have to follow the rules laid out in documents
-using this standard.
+said to be <a>implementation-defined</a> are up to the <a>user agent</a>. In the absence of such
+language, the reverse holds: <a>user agents</a> have to follow the rules laid out in documents using
+this standard.
 
 <p class="example" id=example-implementation-defined>Insert U+000A (LF) code points into
 <var ignore>input</var> in an <a>implementation-defined</a> manner such that each resulting line has

--- a/infra.bs
+++ b/infra.bs
@@ -108,7 +108,7 @@ language, the reverse holds. I.e., <a>user agents</a> have to follow the rules l
 using this standard.
 
 <p class="example" id=example-implementation-defined>Insert U+000A (LF) code points into
-<var ignore>input</var> in an <a>implementation-defined manner</a> such that each resulting line has
+<var ignore>input</var> in an <a>implementation-defined</a> manner such that each resulting line has
 no more than <var ignore>width</var> code points. For the purposes of this requirement, lines are
 delimited by the start of <var ignore>input</var>, the end of <var ignore>input</var>, and
 U+000A (LF).

--- a/infra.bs
+++ b/infra.bs
@@ -102,6 +102,17 @@ retrieving and rendering web content and facilitating end user interaction with 
 specifications using the Infra Standard, the user agent is generally the client software that
 implements the specification.
 
+<p>If something is said to be <dfn export>implementation-defined</dfn>, the particulars of what is
+said to be <a>implementation-defined</a> are up to the <a>user agent</a>. In the absense of such
+language, the reverse holds. I.e., <a>user agents</a> have to follow the rules laid out in documents
+using this standard.
+
+<p class="example" id=example-implementation-defined>Insert U+000A (LF) code points into
+<var ignore>input</var> in an <a>implementation-defined manner</a> such that each resulting line has
+no more than <var ignore>width</var> code points. For the purposes of this requirement, lines are
+delimited by the start of <var ignore>input</var>, the end of <var ignore>input</var>, and
+U+000A (LF).
+
 
 <h3 id=privacy>Privacy concerns</h3>
 


### PR DESCRIPTION
Closes #210.

I noticed that HTML has some instances of UA-defined. That or user-agent-defined might be reasonable alternatives.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/299.html" title="Last updated on Apr 20, 2020, 7:17 AM UTC (e7087a7)">Preview</a> | <a href="https://whatpr.org/infra/299/6536a0d...e7087a7.html" title="Last updated on Apr 20, 2020, 7:17 AM UTC (e7087a7)">Diff</a>