### PR TITLE
Add definitions for string "is" and "identical to"

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -679,21 +679,18 @@ where <a>UTF-8 encode</a> comes into play.
 
 <hr>
 
-<p>A <a>string</a> <var>a</var> <dfn export for=string lt="is|identical to">is</dfn> or is 
-<a for=string>identical to</a> a <a>string</a> <var>b</var> if it consists of the same sequence of 
+<p>A <a>string</a> <var>a</var> <dfn export for=string lt="is|identical to">is</dfn> or is
+<a for=string>identical to</a> a <a>string</a> <var>b</var> if it consists of the same sequence of
 <a>code units</a>.
 
 <p>Except where otherwise stated, all string comparisons use <a for=string>is</a>.
 
-<div class=note>
-
- <p>This type of <a>string</a> comparison was formerly known as a "case-sensitive"
- comparison in HTML. Strings that compare as <a>identical to</a> one another are not only
- sensitive to case variation (such as UPPER and lower case), but also to other code point encoding 
- choices, such as normalization form or the order of combining marks. Two strings that are visually or
- even canonically equivalent according to Unicode might still not be <a>identical to</a>
- each other.
-</div>
+<p class=note>This type of <a>string</a> comparison was formerly known as a "case-sensitive"
+comparison in <cite>HTML</cite>. Strings that compare as <a>identical to</a> one another are not
+only sensitive to case variation (such as UPPER and lower case), but also to other code point
+encoding  choices, such as normalization form or the order of combining marks. Two strings that are
+visually or even canonically equivalent according to Unicode might still not be
+<a for=string>identical to</a> each other. [[HTML]] [[UNICODE]]</p>
 
 <p>A <a>string</a> <var>a</var> is a
 <dfn export lt="code unit prefix|starts with">code unit prefix</dfn> of a <a>string</a> <var>b</var>

--- a/infra.bs
+++ b/infra.bs
@@ -686,10 +686,10 @@ where <a>UTF-8 encode</a> comes into play.
 <p>Except where otherwise stated, all string comparisons use <a for=string>is</a>.
 
 <p class=note>This type of <a>string</a> comparison was formerly known as a "case-sensitive"
-comparison in <cite>HTML</cite>. Strings that compare as <a>identical to</a> one another are not
-only sensitive to case variation (such as UPPER and lower case), but also to other code point
-encoding  choices, such as normalization form or the order of combining marks. Two strings that are
-visually or even canonically equivalent according to Unicode might still not be
+comparison in <cite>HTML</cite>. Strings that compare as <a for=string>identical to</a> one another
+are not only sensitive to case variation (such as UPPER and lower case), but also to other code
+point encoding choices, such as normalization form or the order of combining marks. Two strings that
+are visually or even canonically equivalent according to Unicode might still not be
 <a for=string>identical to</a> each other. [[HTML]] [[UNICODE]]
 
 <p>A <a>string</a> <var>a</var> is a

--- a/infra.bs
+++ b/infra.bs
@@ -690,7 +690,7 @@ comparison in <cite>HTML</cite>. Strings that compare as <a>identical to</a> one
 only sensitive to case variation (such as UPPER and lower case), but also to other code point
 encoding  choices, such as normalization form or the order of combining marks. Two strings that are
 visually or even canonically equivalent according to Unicode might still not be
-<a for=string>identical to</a> each other. [[HTML]] [[UNICODE]]</p>
+<a for=string>identical to</a> each other. [[HTML]] [[UNICODE]]
 
 <p>A <a>string</a> <var>a</var> is a
 <dfn export lt="code unit prefix|starts with">code unit prefix</dfn> of a <a>string</a> <var>b</var>

--- a/infra.bs
+++ b/infra.bs
@@ -679,6 +679,20 @@ where <a>UTF-8 encode</a> comes into play.
 
 <hr>
 
+<p>A <a>string</a> <var>a</var> <dfn export>is</dfn> or is <dfn export>identical to</dfn> a 
+<a>string</a> <var>b</var> if it consists of the same sequence of <a>code units</a>.
+
+<p>Except where otherwise stated, all string comparisons use this definition of string equality.
+
+<div class=note>
+ <p>This type of <a>string</a> comparison was formerly known as <dfn>case-sensitive</dfn> 
+ comparison in HTML. Strings that compare as <a>identical to</a> one another are not only
+ sensitive case variation (such as UPPER and lower case), but also to other code point encoding 
+ choices, such as normalization form or the order of combining marks. Two strings that are visually or
+ even canonically equivalent according to Unicode might still not be <a>identical to</a>
+ each other.
+</div>
+
 <p>A <a>string</a> <var>a</var> is a
 <dfn export lt="code unit prefix|starts with">code unit prefix</dfn> of a <a>string</a> <var>b</var>
 if the following steps return true:

--- a/infra.bs
+++ b/infra.bs
@@ -679,15 +679,16 @@ where <a>UTF-8 encode</a> comes into play.
 
 <hr>
 
-<p>A <a>string</a> <var>a</var> <dfn export>is</dfn> or is <dfn export>identical to</dfn> a 
-<a>string</a> <var>b</var> if it consists of the same sequence of <a>code units</a>.
+<p>A <a>string</a> <var>a</var> <dfn export for=string lt="is|identical to">is</dfn> or is 
+<a for=string>identical to</a> a <a>string</a> <var>b</var> if it consists of the same sequence of 
+<a>code units</a>.
 
-<p>Except where otherwise stated, all string comparisons use this definition of string equality.
+<p>Except where otherwise stated, all string comparisons use <a for=string>is</a>.
 
 <div class=note>
- <p>This type of <a>string</a> comparison was formerly known as <dfn>case-sensitive</dfn> 
+ <p>This type of <a>string</a> comparison was formerly known as "case-sensitive" 
  comparison in HTML. Strings that compare as <a>identical to</a> one another are not only
- sensitive case variation (such as UPPER and lower case), but also to other code point encoding 
+ sensitive to case variation (such as UPPER and lower case), but also to other code point encoding 
  choices, such as normalization form or the order of combining marks. Two strings that are visually or
  even canonically equivalent according to Unicode might still not be <a>identical to</a>
  each other.


### PR DESCRIPTION
Fixes whatwg:html#5067

Adds definitions for string equality comparisons "is" and "identical to". Includes a blanket statement making these the default for string equality. Also includes a note spelling out the relationship to HTML's former "case-sensitive" comparison and appropriate health warning about visual and encoding sequence identity.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/303.html" title="Last updated on May 12, 2020, 3:37 PM UTC (0b5a717)">Preview</a> | <a href="https://whatpr.org/infra/303/6ed08d3...0b5a717.html" title="Last updated on May 12, 2020, 3:37 PM UTC (0b5a717)">Diff</a>