### PR TITLE
Typo: ismorphic

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -277,7 +277,7 @@ algorithm steps and call sites:
 
 <p class=example id=example-algorithm-declaration-short>To <dfn ignore>parse an awesome format</dfn>
 given a [=byte sequence=] <var ignore>bytes</var>, return the result of
-<a lt="ASCII uppercase">ASCII uppercasing</a> the <a lt="isomorphic decode">ismorphic decoding</a>
+<a lt="ASCII uppercase">ASCII uppercasing</a> the <a lt="isomorphic decode">isomorphic decoding</a>
 of <var ignore>bytes</var>.
 
 <p>Types should be included in algorithm declarations, but may be omitted if the parameter name is


### PR DESCRIPTION
Missing a character in this example.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/361.html" title="Last updated on Feb 2, 2021, 5:35 AM UTC (f5d773c)">Preview</a> | <a href="https://whatpr.org/infra/361/3da2ef1...f5d773c.html" title="Last updated on Feb 2, 2021, 5:35 AM UTC (f5d773c)">Diff</a>