### PR TITLE
Add code unit/point substring definitions

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -941,6 +941,69 @@ ordering will not match any particular alphabet or lexicographic order, particul
 
 <hr>
 
+<p>The <dfn export>code unit substring</dfn> from index <var>start</var> with length
+<var>length</var> within a <a>string</a> <var>string</var> is determined as follows:
+
+<ol>
+ <li><p><a>Assert</a>: <var>start</var> and <var>length</var> are greater than 0.</p></li>
+
+ <li><p><a>Assert</a>: <var>start</var> + <var>length</var> is less than or equal to
+ <var>string</var>'s <a for=string>length</a>.</p></li>
+
+ <li><p>Let <var>result</var> be the empty string.</p></li>
+
+ <li><p><a for="set">For each</a> <var>i</var> in <a lt="the exclusive range">the range</a> from
+ <var>start</var> to <var>start</var> + <var>length</var>, exclusive: append the <var>i</var>th
+ <a>code unit</a> of <var>string</var> to <var>result</var>.</p></li>
+
+ <li><p>Return <var>result</var>.</li>
+</ol>
+
+<p>The <dfn export lt="code unit substring by indices">code unit substring</dfn> from indices
+<var>start</var> to <var>end</var> inclusive within a <a>string</a> <var>string</var> is the <a>code
+unit substring</a> from <var>start</var> with length <var>end</var> &minus; <var>start</var> within
+<var>string</var>.
+
+<p class="example" id="example-code-unit-substring">The <a>code unit substring</a> from index 1 with
+length 3 within "<code>Hello world</code>" is "<code>ell</code>". This can also be expressed as the
+<a lt="code unit substring by indices">code unit substring</a> from indices 1 to 4 inclusive.
+
+<p>The <dfn export>code point substring</dfn> within a <a>string</a> <var>string</var> from index
+<var>start</var> with length <var>length</var> is determined as follows:
+
+<ol>
+ <li><p><a>Assert</a>: <var>start</var> and <var>length</var> are greater than 0.</p></li>
+
+ <li><p><a>Assert</a>: <var>start</var> + <var>length</var> is less than or equal to
+ <var>string</var>'s <a for=string>code point length</a>.</p></li>
+
+ <li><p>Let <var>result</var> be the empty string.</p></li>
+
+ <li><p><a for="set">For each</a> <var>i</var> in <a lt="the exclusive range">the range</a> from
+ <var>start</var> to <var>start</var> + <var>length</var>, exclusive: append the <var>i</var>th
+ <a>code point</a> of <var>string</var> to <var>result</var>.</p></li>
+
+ <li><p>Return <var>result</var>.</li>
+</ol>
+
+<p>The <dfn export lt="code point substring by indices">code point substring</dfn> from indices
+<var>start</var> to <var>end</var> inclusive within a <a>string</a> <var>string</var> is the <a>code
+point substring</a> within <var>string</var> from <var>start</var> with length <var>end</var>
+&minus; <var>start</var>.
+
+<div class="example" id="example-code-unit-vs-point-substring">
+ <p>Generally, <a>code unit substring</a> is used when given developer-supplied indices or lengths,
+ since that is how string indexing works in JavaScript. See, for example, the methods of the
+ {{CharacterData}} class. [[DOM]]
+
+ <p>Otherwise, <a>code point substring</a> is likely to be better. For example, the <a>code point
+ substring</a> from index 0 with length 1 within "<code>👽</code>" is "<code>👽</code>", whereas the
+ <a>code unit substring</a> from index 0 with length 1 within "<code>👽</code>" is the <a>string</a>
+ containing the single <a>surrogate</a> U+D83B.
+</div>
+
+<hr>
+
 <p>To <dfn export>isomorphic encode</dfn> a <a>string</a> <var>input</var>, run these steps:</p>
 
 <ol>


### PR DESCRIPTION
Closes #152.

@wanderview would use this in URLPattern.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/391.html" title="Last updated on Aug 12, 2021, 7:51 PM UTC (36e045a)">Preview</a> | <a href="https://whatpr.org/infra/391/d69ac66...36e045a.html" title="Last updated on Aug 12, 2021, 7:51 PM UTC (36e045a)">Diff</a>