### PR TITLE
Allow zero index/length when substringing

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -945,7 +945,7 @@ ordering will not match any particular alphabet or lexicographic order, particul
 <var>length</var> within a <a>string</a> <var>string</var> is determined as follows:
 
 <ol>
- <li><p><a>Assert</a>: <var>start</var> and <var>length</var> are greater than 0.</p></li>
+ <li><p><a>Assert</a>: <var>start</var> and <var>length</var> are nonnegative.</p></li>
 
  <li><p><a>Assert</a>: <var>start</var> + <var>length</var> is less than or equal to
  <var>string</var>'s <a for=string>length</a>.</p></li>
@@ -972,7 +972,7 @@ length 3 within "<code>Hello world</code>" is "<code>ell</code>". This can also 
 <var>start</var> with length <var>length</var> is determined as follows:
 
 <ol>
- <li><p><a>Assert</a>: <var>start</var> and <var>length</var> are greater than 0.</p></li>
+ <li><p><a>Assert</a>: <var>start</var> and <var>length</var> are nonnegative.</p></li>
 
  <li><p><a>Assert</a>: <var>start</var> + <var>length</var> is less than or equal to
  <var>string</var>'s <a for=string>code point length</a>.</p></li>


### PR DESCRIPTION
Followup to cd60f9e3b54e915d4b86b4e09bda6d6ba6d4eb08. Thanks @zcorpan.

I suspect this might have been what @annevk meant in https://github.com/whatwg/infra/pull/391#discussion_r688469718 but I misinterpreted.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/395.html" title="Last updated on Aug 16, 2021, 4:23 PM UTC (5f20af2)">Preview</a> | <a href="https://whatpr.org/infra/395/cd60f9e...5f20af2.html" title="Last updated on Aug 16, 2021, 4:23 PM UTC (5f20af2)">Diff</a>