### PR TITLE
Add "start with" as link text for byte sequence's "starts with"

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -971,7 +971,7 @@ unit substring</a> from <var>start</var> with length <var>end</var> &minus; <var
 
 <p class="example" id="example-code-unit-substring">The <a>code unit substring</a> from 1 with
 length 3 within "<code>Hello world</code>" is "<code>ell</code>". This can also be expressed as the
-<a lt="code unit substring by indices">code unit substring</a> from 1 to 4.
+<a lt="code unit substring by positions">code unit substring</a> from 1 to 4.
 
 <p class="note">The numbers given to these algorithms are best thought of as positions
 <em>between</em> <a>code units</a>, not indices of the code units themselves. The substring returned
@@ -1004,7 +1004,7 @@ is the empty string, even though there is no code unit at index 0 within the emp
 
 <p>The <dfn export lt="code point substring to the end of the string">code point substring</dfn>
 from <var>start</var> to the end of a <a>string</a> <var>string</var> is the
-<a lt="code point substring by indices">code point substring</a> from <var>start</var> to
+<a lt="code point substring by positions">code point substring</a> from <var>start</var> to
 <var>string</var>'s <a for=string>code point length</a> within <var>string</var>.
 
 <div class="example" id="example-code-unit-vs-point-substring">

--- a/infra.bs
+++ b/infra.bs
@@ -693,7 +693,7 @@ following steps return true:
  </li>
 </ol>
 
-<p>"<var>input</var> <dfn export for="byte sequence" lt="start with|starts with">starts with</dfn>
+<p>"<var>input</var> <dfn export for="byte sequence" lt="starts with|start with">starts with</dfn>
 <var>potentialPrefix</var> can be used as a synonym for "<var>potentialPrefix</var> is a
 <a for="byte sequence">prefix</a> of <var>input</var>".
 

--- a/infra.bs
+++ b/infra.bs
@@ -693,9 +693,9 @@ following steps return true:
  </li>
 </ol>
 
-<p>"<var>input</var> <dfn export for="byte sequence">starts with</dfn> <var>potentialPrefix</var>
-can be used as a synonym for "<var>potentialPrefix</var> is a <a for="byte sequence">prefix</a> of
-<var>input</var>".
+<p>"<var>input</var> <dfn export for="byte sequence" lt="start with|starts with">starts with</dfn>
+<var>potentialPrefix</var> can be used as a synonym for "<var>potentialPrefix</var> is a
+<a for="byte sequence">prefix</a> of <var>input</var>".
 
 <p>A <a>byte sequence</a> <var>a</var> is <dfn export>byte less than</dfn> a <a>byte sequence</a>
 <var>b</var> if the following steps return true:


### PR DESCRIPTION
This is useful for the negative case "If _foo_ does not **start with** _bar_".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/407.html" title="Last updated on Sep 28, 2021, 9:23 AM UTC (964acd1)">Preview</a> | <a href="https://whatpr.org/infra/407/9323562...964acd1.html" title="Last updated on Sep 28, 2021, 9:23 AM UTC (964acd1)">Diff</a>