### PR TITLE
Remove pairs

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1581,8 +1581,8 @@ a <a>map</a> |map|, with a less than algorithm |lessThanAlgo|, is to create a ne
 <h3 id=structs>Structs</h3>
 
 <p>A <dfn export>struct</dfn> is a specification type consisting of a finite set of
-<dfn export for=struct,tuple,pair lt=item>items</dfn>, each of which has a unique and immutable
-<dfn export for=struct,tuple,pair>name</dfn>.
+<dfn export for=struct,tuple lt=item>items</dfn>, each of which has a unique and immutable
+<dfn export for=struct,tuple>name</dfn>.
 
 
 <h4 id=tuples>Tuples</h4>
@@ -1614,15 +1614,6 @@ to the <a>tuple</a>. An indexing syntax can be used by providing a zero-based in
 <p class=note>It is intentional that not all <a>structs</a> are <a>tuples</a>. Documents using the
 Infra Standard might need the flexibility to add new <a for=struct>names</a> to their struct
 without breaking literal syntax used by their dependencies. In that case a tuple is not appropriate.
-
-<hr>
-
-<p><a>Tuples</a> with two <a for=tuple>items</a> are also known as <dfn export lt=pair>pairs</dfn>.
-For <a>pairs</a>, a slightly shorter literal syntax can be used, separating the two
-<a for=pair>items</a> with a / character.
-
-<p class=example id=example-pair>Another way of expressing our |statusInstance| tuple above would be
-as 200/`<code>OK</code>`.
 
 
 <h2 id=json>JSON</h2>


### PR DESCRIPTION
Overall this syntax was somewhat confusing as the slash is used for many other purposes.

Fetch was using this syntax, but that is being addressed in https://github.com/whatwg/fetch/pull/1339.

Fixes #127.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/413.html" title="Last updated on Oct 22, 2021, 9:32 AM UTC (7be3d44)">Preview</a> | <a href="https://whatpr.org/infra/413/5ccbe0d...7be3d44.html" title="Last updated on Oct 22, 2021, 9:32 AM UTC (7be3d44)">Diff</a>