### PR TITLE
Changed link 'for lists' to 'lists'

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -518,7 +518,7 @@ something.
 
 <dl>
  <dt>For each
- <dd><p>As defined <a for=list lt="for each">for lists</a> (and derivatives) and
+ <dd><p>As defined for <a for=list lt="for each">lists</a> (and derivatives) and
  <a for=map lt="for each">maps</a>.
 
  <dt><dfn export for=iteration lt=while>While</dfn>


### PR DESCRIPTION
Changed link 'for lists' to 'lists'

Fixes #406.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/426.html" title="Last updated on Dec 29, 2021, 12:43 AM UTC (fa667df)">Preview</a> | <a href="https://whatpr.org/infra/426/38ac4e1...fa667df.html" title="Last updated on Dec 29, 2021, 12:43 AM UTC (fa667df)">Diff</a>