### PR TITLE
Don't export character as an alias of code point

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -728,7 +728,7 @@ the same order.
 
 <h3 id=code-points>Code points</h3>
 
-<p>A <dfn export lt="code point|character">code point</dfn> is a Unicode code point and is
+<p>A <dfn export>code point</dfn> is a Unicode code point and is
 represented as "U+" followed by four-to-six <a>ASCII upper hex digits</a>, in the range U+0000 to
 U+10FFFF, inclusive. A <a>code point</a>'s <dfn export for="code point">value</dfn> is its
 underlying number.


### PR DESCRIPTION
“Character” is an ambiguous term and is used in multiple senses in the Web platform. Don't alias it to only one of them. #449


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/450.html" title="Last updated on May 5, 2022, 2:44 AM UTC (fe1656c)">Preview</a> | <a href="https://whatpr.org/infra/450/3deb8ac...fe1656c.html" title="Last updated on May 5, 2022, 2:44 AM UTC (fe1656c)">Diff</a>