### PR TITLE
Add example of code-unit-less-than being counterintuitive. Fixes #388

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -987,9 +987,10 @@ string, producing a highly efficient, consistent, and deterministic sort order. 
 ordering will not match any particular alphabet or lexicographic order, particularly for
 <a>code points</a> represented by a surrogate pair. [[!ECMA-262]]
 
-<p class="example" id="example-code-unit-less-than">For example, the code point U+FF5E FULLWIDTH TILDE (～) is obviously less than the
-code point U+1F600 (😀), but the tilde is composed of a single code unit 0xFF5E, while the smiley is
-composed of two code units 0xD83D and 0XDE00, so the smiley is [=code unit less than=] the tilde.
+<p class="example" id="example-code-unit-less-than">For example, the code point U+FF5E FULLWIDTH
+TILDE (～) is obviously less than the code point U+1F600 (😀), but the tilde is composed of a single
+code unit 0xFF5E, while the smiley is composed of two code units 0xD83D and 0XDE00, so the smiley is
+[=code unit less than=] the tilde.
 
 <hr>
 

--- a/infra.bs
+++ b/infra.bs
@@ -985,10 +985,11 @@ literal, we can use plainer language: <var>domain</var> <a for=string>ends with<
 {{Array/sort()}} method on an array of strings. This ordering compares the 16-bit code units in each
 string, producing a highly efficient, consistent, and deterministic sort order. The resulting
 ordering will not match any particular alphabet or lexicographic order, particularly for
-<a>code points</a> represented by a surrogate pair. For example, the codepoint U+FF5E
-(～ FULLWIDTH TILDE) is obviously less than the codepoint U+1F600 (😀), but the tilde is
-composed of a single code unit 0xFF5E, while the smiley is composed of two code units
-0xD83D and 0XDE00, so the smiley is [=code unit less than=] the tilde. [[!ECMA-262]]
+<a>code points</a> represented by a surrogate pair. [[!ECMA-262]]
+
+<p class="example">For example, the code point U+FF5E FULLWIDTH TILDE (～) is obviously less than the
+code point U+1F600 (😀), but the tilde is composed of a single code unit 0xFF5E, while the smiley is
+composed of two code units 0xD83D and 0XDE00, so the smiley is [=code unit less than=] the tilde.
 
 <hr>
 

--- a/infra.bs
+++ b/infra.bs
@@ -988,8 +988,7 @@ ordering will not match any particular alphabet or lexicographic order, particul
 <a>code points</a> represented by a surrogate pair. For example, the codepoint U+FF5E
 (～ FULLWIDTH TILDE) is obviously less than the codepoint U+1F600 (😀), but the tilde is
 composed of a single code unit 0xFF5E, while the smiley is composed of two code units
-0xD83D and 0XDE00, so the smiley is [=code unit less than=] the tilde.
-[[!ECMA-262]]
+0xD83D and 0XDE00, so the smiley is [=code unit less than=] the tilde. [[!ECMA-262]]
 
 <hr>
 

--- a/infra.bs
+++ b/infra.bs
@@ -985,7 +985,11 @@ literal, we can use plainer language: <var>domain</var> <a for=string>ends with<
 {{Array/sort()}} method on an array of strings. This ordering compares the 16-bit code units in each
 string, producing a highly efficient, consistent, and deterministic sort order. The resulting
 ordering will not match any particular alphabet or lexicographic order, particularly for
-<a>code points</a> represented by a surrogate pair. [[!ECMA-262]]
+<a>code points</a> represented by a surrogate pair. For example, the codepoint U+FF5E
+(～ FULLWIDTH TILDE) is obviously less than the codepoint U+1F600 (😀), but the tilde is
+composed of a single code unit 0xFF5E, while the smiley is composed of two code units
+0xD83D and 0XDE00, so the smiley is [=code unit less than=] the tilde.
+[[!ECMA-262]]
 
 <hr>
 

--- a/infra.bs
+++ b/infra.bs
@@ -987,7 +987,7 @@ string, producing a highly efficient, consistent, and deterministic sort order. 
 ordering will not match any particular alphabet or lexicographic order, particularly for
 <a>code points</a> represented by a surrogate pair. [[!ECMA-262]]
 
-<p class="example">For example, the code point U+FF5E FULLWIDTH TILDE (～) is obviously less than the
+<p class="example" id="example-code-unit-less-than">For example, the code point U+FF5E FULLWIDTH TILDE (～) is obviously less than the
 code point U+1F600 (😀), but the tilde is composed of a single code unit 0xFF5E, while the smiley is
 composed of two code units 0xD83D and 0XDE00, so the smiley is [=code unit less than=] the tilde.
 


### PR DESCRIPTION
Added an example to the note, utilizing fullwidth tilde (a single code unit) and smiley (higher codepoint, but two code units).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/452.html" title="Last updated on May 6, 2022, 7:53 PM UTC (616d16f)">Preview</a> | <a href="https://whatpr.org/infra/452/3deb8ac...616d16f.html" title="Last updated on May 6, 2022, 7:53 PM UTC (616d16f)">Diff</a>