### PR TITLE
Add documentation for tuple multiple assignment

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -427,6 +427,21 @@ behavior; otherwise null.
 <a href=https://en.wikipedia.org/wiki/Scope_(computer_science)#Block_scope>block scoped</a>.
 Variables must not be declared more than once per algorithm.
 
+<p>A multiple assignment syntax can be used to assign multiple variables to the <a>tuple</a>'s
+<a for=tuple>items</a>, by surrounding the variable names with parenthesis and separating each
+variable name by a comma. The number of variables assigned cannot differ from the number of
+<a for=tuple>items</a> in the <a>tuple</a>.
+
+<div class=example id=example-tuple-multiple-assignment>
+ <ol>
+  <li><p>Let |statusInstance| be the status (200, `<code>OK</code>`).
+  <li><p>Let (|status|, |statusMessage|) be |statusInstance|.
+ </ol>
+
+ <p>Assigning |status| and |statusMessage| could be written as two separate steps that use an index
+ or <a for=tuple>name</a> to access the <a>tuple</a>'s <a for=tuple>items</a>.
+</div>
+
 
 <h3 id=algorithm-control-flow>Control flow</h3>
 


### PR DESCRIPTION
"Let (variableOne, variableTwo) be the result of functionReturningTuple" is a valid statement, document multiple asignment usage and write a basic example.

Fixes: #508


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/512.html" title="Last updated on Dec 21, 2022, 6:28 AM UTC (c8e206d)">Preview</a> | <a href="https://whatpr.org/infra/512/171a136...c8e206d.html" title="Last updated on Dec 21, 2022, 6:28 AM UTC (c8e206d)">Diff</a>