### PR TITLE
Algorithms should specify their return type in more cases.

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -297,8 +297,8 @@ a [=byte sequence=] <var ignore>bytes</var>, perform the following steps. They r
 [=string=] or null.
 
 <p>Algorithms which do not return a value use a shorter form. This same shorter form can be used even
-for algorithms that do return a value, since the return type is relatively easy to infer from the
-algorithm steps and call sites:
+for algorithms that do return a value if the return type is relatively easy to infer from the
+algorithm steps:
 
 <p class=exemplary-prose>To <dfn ignore>[algorithm name]</dfn>, given a [type1]
 <var ignore>[parameter1]</var>, a [type2] <var ignore>[parameter2]</var>, &hellip;:</p>


### PR DESCRIPTION
It's wrong to assert that return types are always easy to infer from
algorithm steps and call sites. We also shouldn't make people read
through the call sites (which might be in other documents) to figure out
what an algorithm returns.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#algorithm-declaration
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/581.html#algorithm-declaration" title="Last updated on May 25, 2023, 8:42 PM UTC (6d395a0)">Preview</a> | <a href="https://whatpr.org/infra/581/0dba3a2...6d395a0.html" title="Last updated on May 25, 2023, 8:42 PM UTC (6d395a0)">Diff</a>