### PR TITLE
Add a definition of less-than sign

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -825,7 +825,7 @@ U+007F DELETE, inclusive.
 <p>An <dfn export lt="ASCII tab or newline|ASCII tabs or newlines">ASCII tab or newline</dfn> is
 U+0009 TAB, U+000A LF, or U+000D CR.
 
-<p><dfn export>ASCII whitespace</dfn> is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020
+<p>An <dfn export>ASCII whitespace</dfn> is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020
 SPACE.
 
 <p class=note>"Whitespace" is a mass noun.
@@ -860,6 +860,8 @@ U+007A (z), inclusive.
 <p>An <dfn export>ASCII alpha</dfn> is an <a>ASCII upper alpha</a> or <a>ASCII lower alpha</a>.
 
 <p>An <dfn export>ASCII alphanumeric</dfn> is an <a>ASCII digit</a> or <a>ASCII alpha</a>.
+
+<p>A <dfn export>less-than sign</dfn> is U+003C LESS-THAN SIGN (&lt;).
 
 
 <h3 id=strings>Strings</h3>
@@ -2044,6 +2046,7 @@ Jakob Ackermann<!-- das7pad; GitHub -->,
 Jake Archibald,
 Jeff Hodges,
 Jeffrey Yasskin,
+Jun Kokatsu,
 Jungkee Song,
 Leonid Vasilyev,
 Maciej Stachowiak,


### PR DESCRIPTION
Define less-than sign which needs to be used in https://github.com/whatwg/html/pull/9309.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/589.html" title="Last updated on Jun 26, 2023, 4:13 AM UTC (afa01db)">Preview</a> | <a href="https://whatpr.org/infra/589/dbc268d...afa01db.html" title="Last updated on Jun 26, 2023, 4:13 AM UTC (afa01db)">Diff</a>