### PR TITLE
Italicize the variable name 'target' in the second occurrence

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -453,7 +453,7 @@ of related values is used as the input to multiple algorithms.
 </div>
 
 <p class=example id=example-variable-ternary>Let <var ignore>activationTarget</var> be
-<var ignore>target</var> if <var ignore>isActivationEvent</var> is true and target has activation
+<var ignore>target</var> if <var ignore>isActivationEvent</var> is true and <var ignore>target</var> has activation
 behavior; otherwise null.
 
 <p>Variables must not be used before they are declared. Variables are


### PR DESCRIPTION
This pull request fixes a minor inconsistency in the infra standard > §3.5 Variables > Third example. In this example, the variable target was italicized in the first occurrence but not in the second occurrence, which could cause confusion for readers. I have corrected the formatting of the variable name in the second occurrence.

This issue was reported by @annevk

I have attached a screenshot of the bug and a screenshot of our chat session where we discussed the problem and the solution. I appreciate your feedback and approval of this pull request.

- Screenshot of the bug.
![image](https://github.com/whatwg/infra/assets/84291149/314ce95e-1ffd-4e70-8dd6-6e664cf4822f)

- Screenshot of the Chat Session

![image](https://github.com/whatwg/infra/assets/84291149/a20d74e8-d006-48da-916a-93613e51bf64)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/629.html" title="Last updated on Jan 12, 2024, 2:34 PM UTC (10fa5cb)">Preview</a> | <a href="https://whatpr.org/infra/629/36925b8...10fa5cb.html" title="Last updated on Jan 12, 2024, 2:34 PM UTC (10fa5cb)">Diff</a>