### PR TITLE
Meta: export convert an Infra value to a (JSON) JavaScript value

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1974,7 +1974,8 @@ given a <a>string</a>, <a>boolean</a>, number, null, <a>list</a>, or <a>string</
  <li><p>Return the result of running <a>UTF-8 encode</a> on |string|. [[!ENCODING]]
 </ol>
 
-<p>To <dfn lt="convert an Infra value to a JSON-compatible JavaScript value|converting an Infra value to a JSON-compatible JavaScript value">convert an Infra value to a JSON-compatible JavaScript value</dfn>,
+<p>To
+<dfn export lt="convert an Infra value to a JSON-compatible JavaScript value|converting an Infra value to a JSON-compatible JavaScript value">convert an Infra value to a JSON-compatible JavaScript value</dfn>,
 given |value|:
 
 <ol>


### PR DESCRIPTION
Also known as convert an Infra value to a JSON-compatible JavaScript value, but that exceeded 72 characters.

---

I use this in https://github.com/w3c/push-api/pull/385.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/642.html" title="Last updated on Aug 26, 2024, 3:19 PM UTC (2ec88eb)">Preview</a> | <a href="https://whatpr.org/infra/642/0805cea...2ec88eb.html" title="Last updated on Aug 26, 2024, 3:19 PM UTC (2ec88eb)">Diff</a>