### PR TITLE
Warn that Infra's and XML's notion of ascii whitespace aren't the same.

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -933,7 +933,19 @@ SPACE.
 
 <p class=note>"Whitespace" is a mass noun.
 
-<p class=note>[[xml10#NT-S|XML's definition of whitespace]] omits U+000C FF.
+<div class=note>
+ <p>The XML, JSON, and parts of the HTTP specifications exclude U+000C FF in their definition of
+ whitespace:
+
+ <ul class=brief>
+  <li>[[xml10#NT-S|XML's S production]]
+  <li>[[JSON#section-2|JSON's ws production]]
+  <li>[=HTTP whitespace=]
+ </ul>
+
+ <p>Prefer using Infra's [=ASCII whitespace=] definition for new features, unless your specification
+ deals exclusively with XML/JSON/HTTP.
+</div>
 
 <p>A <dfn export>C0 control</dfn> is a <a>code point</a> in the range U+0000 NULL to
 U+001F INFORMATION SEPARATOR ONE, inclusive.

--- a/infra.bs
+++ b/infra.bs
@@ -933,6 +933,8 @@ SPACE.
 
 <p class=note>"Whitespace" is a mass noun.
 
+<p class=note>[[xml11#NT-S|XML's definition of whitespace]] omits U+000C FF.
+
 <p>A <dfn export>C0 control</dfn> is a <a>code point</a> in the range U+0000 NULL to
 U+001F INFORMATION SEPARATOR ONE, inclusive.
 

--- a/infra.bs
+++ b/infra.bs
@@ -933,7 +933,7 @@ SPACE.
 
 <p class=note>"Whitespace" is a mass noun.
 
-<p class=note>[[xml11#NT-S|XML's definition of whitespace]] omits U+000C FF.
+<p class=note>[[xml10#NT-S|XML's definition of whitespace]] omits U+000C FF.
 
 <p>A <dfn export>C0 control</dfn> is a <a>code point</a> in the range U+0000 NULL to
 U+001F INFORMATION SEPARATOR ONE, inclusive.


### PR DESCRIPTION
This change is inspired by [Candidate Correction 4 in EPUB](https://www.w3.org/TR/2024/REC-epub-33-20241017/#change_4), where they accidentally used the Infra definition of whitespace where they'd meant the XML one. See https://github.com/w3c/epub-specs/issues/2637 by @mattgarrish. Their citation is to XML 1.0, but the definitions are the same between 1.0 and 1.1.

I'm not tied to the exact wording here, but it seems worth warning about the semantic difference as Infra gets more widely used in non-HTML contexts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#ascii-whitespace
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/649.html#ascii-whitespace" title="Last updated on Nov 20, 2024, 7:36 PM UTC (f3306fa)">Preview</a> | <a href="https://whatpr.org/infra/649/2410293...f3306fa.html" title="Last updated on Nov 20, 2024, 7:36 PM UTC (f3306fa)">Diff</a>