### PR TITLE
Meta: fix exported JSON terms regression

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1898,8 +1898,9 @@ specification. [[!ECMA-262]]
 </div>
 
 <div algorithm>
-<p>To <dfn export>parse JSON bytes to a JavaScript value</dfn>, given a <a>byte sequence</a>
-|bytes|:
+<p>To
+<dfn export lt="parse JSON bytes to a JavaScript value|parse JSON from bytes">parse JSON bytes to a JavaScript value</dfn>,
+given a <a>byte sequence</a> |bytes|:
 
 <ol>
  <li><p>Let |string| be the result of running <a>UTF-8 decode</a> on |bytes|. [[!ENCODING]]
@@ -1932,8 +1933,9 @@ specification. [[!ECMA-262]]
 </div>
 
 <div algorithm>
-<p>To <dfn export>serialize a JavaScript value to JSON bytes</dfn>, given a JavaScript value
-|value|:
+<p>To
+<dfn export lt="serialize a JavaScript value to JSON bytes|serialize JSON to bytes">serialize a JavaScript value to JSON bytes</dfn>,
+given a JavaScript value |value|:
 
 <ol>
  <li><p>Let |string| be the result of <a>serializing a JavaScript value to a JSON string</a> given


### PR DESCRIPTION
In 79b945da6b3e3be12473a276da8db5ceb1ed45be I unintentionally dropped "parse JSON from bytes" and "serialize JSON to bytes", breaking Fetch builds in the process.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/650.html" title="Last updated on Nov 19, 2024, 7:47 AM UTC (5d026ef)">Preview</a> | <a href="https://whatpr.org/infra/650/2410293...5d026ef.html" title="Last updated on Nov 19, 2024, 7:47 AM UTC (5d026ef)">Diff</a>