### PR TITLE
Define difference for Sets

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1726,6 +1726,10 @@ of creating a new <a>ordered set</a> |set| and, <a for=list>for each</a> |item| 
 <a for=list>cloning</a> |A| as |set| and, <a for=list>for each</a> |item| of |B|,
 <a for=set>appending</a> |item| to |set|.
 
+<p>The <dfn export for=set>difference</dfn> of <a>ordered sets</a> |A| and |B|, is the result
+of creating a new <a>ordered set</a> |set| and, <a for=list>for each</a> |item| of |A|, if |B|
+[=set/contains|does not contain=] |item|, <a for=set>appending</a> |item| to |set|.
+
 <hr>
 
 <p><dfn export lt="the range|the inclusive range">The range</dfn> <var>n</var> to <var>m</var>,


### PR DESCRIPTION
In WebDriver BiDi specification, we have use cases for using the difference operation on two sets.
This PR adds a definition for the difference operation for two sets.

Closes https://github.com/whatwg/infra/issues/632


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/658.html" title="Last updated on Dec 10, 2024, 6:40 PM UTC (f382761)">Preview</a> | <a href="https://whatpr.org/infra/658/2e8f05a...f382761.html" title="Last updated on Dec 10, 2024, 6:40 PM UTC (f382761)">Diff</a>