### PR TITLE
Define an algorithm to create a Set from a List

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1694,6 +1694,16 @@ unordered one, since interoperability requires that any developer-exposed enumer
 contents be consistent between browsers. In those cases where order is not important, we still use
 ordered sets; implementations can optimize based on the fact that the order is not observable.
 
+<div algorithm>
+<p>To <dfn export for=set>create</dfn> a [=/set=], from a [=/list=] |input|:
+
+<ol>
+ <li><p>Let |result| be an empty [=/set=].
+ <li><p>For each [=list/item=] |item| in |input|, [=set/append=] |item| to |result|.
+ <li><p>Return |result|.
+</ol>
+</div>
+
 <p>To <dfn export for=set>append</dfn> to an <a>ordered set</a>: if the set <a for=list>contains</a>
 the given <a for=set>item</a>, then do nothing; otherwise, perform the normal <a>list</a>
 <a for=list>append</a> operation.

--- a/infra.bs
+++ b/infra.bs
@@ -1695,11 +1695,11 @@ contents be consistent between browsers. In those cases where order is not impor
 ordered sets; implementations can optimize based on the fact that the order is not observable.
 
 <div algorithm>
-<p>To <dfn export for=set>create</dfn> a [=/set=], from a [=/list=] |input|:
+<p>To <dfn export for=set>create</dfn> a [=/set=], given a [=/list=] |input|:
 
 <ol>
  <li><p>Let |result| be an empty [=/set=].
- <li><p>For each [=list/item=] |item| in |input|, [=set/append=] |item| to |result|.
+ <li><p>[=list/for each=] |item| of |input|, [=set/append=] |item| to |result|.
  <li><p>Return |result|.
 </ol>
 </div>

--- a/infra.bs
+++ b/infra.bs
@@ -1699,7 +1699,7 @@ ordered sets; implementations can optimize based on the fact that the order is n
 
 <ol>
  <li><p>Let |result| be an empty [=/set=].
- <li><p>[=list/for each=] |item| of |input|, [=set/append=] |item| to |result|.
+ <li><p>[=list/For each=] |item| of |input|, [=set/append=] |item| to |result|.
  <li><p>Return |result|.
 </ol>
 </div>


### PR DESCRIPTION
In the WebDriver BiDi spec, there is a need to convert lists created from JSON messages into sets for internal algorithms. This PR adds a helper to define how the operation of creating a set from a list should be performed. The operation seems to be common and relatively straight-forward so it might make sense that the Infra standard defines it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/659.html" title="Last updated on Dec 19, 2024, 7:18 AM UTC (ca83296)">Preview</a> | <a href="https://whatpr.org/infra/659/7351436...ca83296.html" title="Last updated on Dec 19, 2024, 7:18 AM UTC (ca83296)">Diff</a>