### PR TITLE
Define equality for sets

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1718,6 +1718,9 @@ of either with <var>replacement</var> and <a for=set>remove</a> all other instan
 <p class=note>This implies that an <a>ordered set</a> is both a <a for=set>subset</a> and a
 <a for=set>superset</a> of itself.
 
+<p>A [=/set=] |A| is <dfn export for=set>equal</dfn> to a [=/set=] |B|
+if |A| is a [=subset=] of |B| and |A| is a [=superset=] of |B|.
+
 <p>The <dfn export for=set>intersection</dfn> of <a>ordered sets</a> |A| and |B|, is the result
 of creating a new <a>ordered set</a> |set| and, <a for=list>for each</a> |item| of |A|, if |B|
 <a for=set>contains</a> |item|, <a for=set>appending</a> |item| to |set|.


### PR DESCRIPTION
A definition of what it means for two sets to be equal. This definition re-uses the subset/superset definitions but we could also define it as an iteration over elements and size equality.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/660.html" title="Last updated on Jan 10, 2025, 9:35 AM UTC (1aca0e5)">Preview</a> | <a href="https://whatpr.org/infra/660/7351436...1aca0e5.html" title="Last updated on Jan 10, 2025, 9:35 AM UTC (1aca0e5)">Diff</a>