### PR TITLE
Add set extend operation

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1542,8 +1542,8 @@ list multiple assignment syntax is used.
 <p>To <dfn export for=list>append</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
 add the given <a for=list>item</a> to the end of the list.
 
-<p>To <dfn export for=list>extend</dfn> a <a>list</a> |A| with a <a>list</a> |B|,
-<a for=list>for each</a> |item| of |B|, <a for=list>append</a> |item| to |A|.
+<p>To <dfn export for=list>extend</dfn> a <a>list</a> that is not an <a>ordered set</a> |A| with a
+<a>list</a> |B|, <a for=list>for each</a> |item| of |B|, <a for=list>append</a> |item| to |A|.
 
 <div class=example id=example-list-extend>
  <ol>
@@ -1708,6 +1708,9 @@ ordered sets; implementations can optimize based on the fact that the order is n
 <p>To <dfn export for=set>append</dfn> to an <a>ordered set</a>: if the set <a for=list>contains</a>
 the given <a for=set>item</a>, then do nothing; otherwise, perform the normal <a>list</a>
 <a for=list>append</a> operation.
+
+<p>To <dfn export for=set>extend</dfn> an [=ordered set=] |A| with a [=list=] |B|, [=list/for each=]
+|item| of |B|, [=set/append=] |item| to |A|.
 
 <p>To <dfn export for=set>prepend</dfn> to an <a>ordered set</a>: if the set
 <a for=list>contains</a> the given <a for=set>item</a>, then do nothing; otherwise, perform the


### PR DESCRIPTION
"List extend" didn't really work since it used "list append", which doesn't properly handle duplicates.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/663.html" title="Last updated on Jan 29, 2025, 6:47 AM UTC (dda9b15)">Preview</a> | <a href="https://whatpr.org/infra/663/48531ec...dda9b15.html" title="Last updated on Jan 29, 2025, 6:47 AM UTC (dda9b15)">Diff</a>