### PR TITLE
Review Draft Publication: July 2025

### DIFF
--- a/review-drafts/2025-07.bs
+++ b/review-drafts/2025-07.bs
@@ -1,5 +1,7 @@
 <pre class=metadata>
 Group: WHATWG
+Status: RD
+Date: 2025-07-21
 H1: Infra
 Shortname: infra
 Text Macro: TWITTER infrastandard


### PR DESCRIPTION
The [July 2025 Review Draft](https://infra.spec.whatwg.org/review-drafts/2025-07/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.