### PR TITLE
Define singleton types.

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1484,7 +1484,7 @@ these steps:
 <h3 id=singleton>Singletons</h3>
 
 The following types can be used as inputs or outputs of algorithmic prose to improve comprehension.
-They have no web-visible representation beyond their effect on the flow of any given algorithm, and
+They have no observable representation beyond their effect on the flow of any given algorithm, and
 they can only be compared with "is".
 
 <dl>
@@ -1517,7 +1517,7 @@ they can only be compared with "is".
  <ol>
   <li><p>If <var>result</var> is <a>failure</a>, then shut everything down gracefully and abort.
   <li><p><a>Assert</a>: <var>result</var> is <a>success</a>.
-  <li><p>...
+  <li><p>…
  </ol>
 </div>
 


### PR DESCRIPTION
This commit defines a set of "singleton" types which are commonly used as inputs or outputs to prose algorithms: "success"/"failure", and "allowed"/"blocked".

This is a first pass at whatwg/infra#686 for discussion.

I'm not entirely convinced about the name, but naming is hard and I'm happy to run with "singleton types" if that's what makes sense to folks. Other things that occurred to me were "[sentinel](https://en.wikipedia.org/wiki/Sentinel_value) types" or shifting this away from the "type" framing into the algorithm section as "named inputs/outputs". But I don't have strong opinions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/687.html" title="Last updated on Nov 24, 2025, 7:31 AM UTC (34ef09a)">Preview</a> | <a href="https://whatpr.org/infra/687/096add4...34ef09a.html" title="Last updated on Nov 24, 2025, 7:31 AM UTC (34ef09a)">Diff</a>