### PR TITLE
Add `has duplicates` to list, and let `remove` return a boolean of whether items were removed

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -1712,16 +1712,19 @@ To <dfn export for=list>remove duplicates</dfn> from a <a>list</a> <var>list</va
 </div>
 
 <div algorithm=has-duplicates>
-To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>, perform the following steps:
+To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
 
 <ol>
- <li><p>Let <var>result</var> be an empty <a>list</a>.
+ <li><p>Let <var>result</var> be « ».
 
- <li><p><a for=set>For each</a> |item| of <var>list</var>:
+ <li>
+  <p><a for=set>For each</a> |item| of <var>list</var>:</p>
 
   <ol>
    <li><p>If <var>result</var> <a for=list>contains</a> |item|, return true.</p></li>
+   <li><p><a for=list>Append</a> |item| to <var>result</var>.</p></li>
   </ol>
+ </li>
 
  <li><p>Return false.</p></li>
 </ol>

--- a/infra.bs
+++ b/infra.bs
@@ -1691,7 +1691,7 @@ To <dfn export for=list,set>potentialy remove</dfn> zero or more <a for=list>ite
 
  <li><p><a for=list,set>Remove</a> the items from |list| based on the given condition.
 
- <li><p>Return true if |list|'s <a for=list>size</a> is less than |sizeBefore|, and false otherwise.
+ <li><p>Return true if |list|'s <a for=list>size</a> is less than |sizeBefore|; otherwise false.
 </ol>
 </div>
 

--- a/infra.bs
+++ b/infra.bs
@@ -1692,7 +1692,7 @@ following steps. They return a <a>list</a> of the same designation as |list|.
 </ol>
 </div>
 
-<div algorithm=has-duplicates>
+<div algorithm>
 To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
 
 <ol>

--- a/infra.bs
+++ b/infra.bs
@@ -1702,7 +1702,7 @@ To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
   <p><a for=set>For each</a> |item| of <var>list</var>:
 
   <ol>
-   <li><p>If <var>seenItems</var> <a for=list>contains</a> |item|, return true.</p></li>
+   <li><p>If <var>seenItems</var> <a for=list>contains</a> |item|, then return true.</p></li>
 
    <li><p><a for=list>Append</a> |item| to <var>seenItems</var>.</p></li>
   </ol>

--- a/infra.bs
+++ b/infra.bs
@@ -1687,7 +1687,7 @@ following steps. They return a <a>list</a> of the same designation as |list|.
 To <dfn export for=list,set>potentialy remove</dfn> zero or more <a for=list>items</a> from a <a>list</a> |list| based on a condition:
 
 <ol>
- <li><p>If no item in |list| matches the given condition <a for=list,set>exists</a>, return false.
+ <li><p>If no item in |list| matches the given condition <a for=list,set>exists</a>, then return false.
 
  <li><p><a for=list,set>Remove</a> the items from |list|.
 

--- a/infra.bs
+++ b/infra.bs
@@ -1684,7 +1684,7 @@ following steps. They return a <a>list</a> of the same designation as |list|.
 </div>
 
 <div algorithm=porentially-remove>
-To <dfn export for=list,set>potentialy remove</dfn> zero or more <a for=list>items</a> from a <a>list</a> |list| based on a condition, perform the following steps:
+To <dfn export for=list,set>potentialy remove</dfn> zero or more <a for=list>items</a> from a <a>list</a> |list| based on a condition:
 
 <ol>
  <li><p>If no item in |list| matches the given condition <a for=list,set>exists</a>, return false.

--- a/infra.bs
+++ b/infra.bs
@@ -1695,22 +1695,6 @@ To <dfn export for=list,set>potentialy remove</dfn> zero or more <a for=list>ite
 </ol>
 </div>
 
-<div algorithm=remove-duplicates>
-To <dfn export for=list>remove duplicates</dfn> from a <a>list</a> <var>list</var>, perform the following steps:
-
-<ol>
- <li><p>Let <var>result</var> be an empty <a>list</a>.
-
- <li><p><a for=set>For each</a> |item| of <var>list</var>:
-
-  <ol>
-   <li><p>If <var>result</var> does not <a for=list>contain</a> |item|, <a for=list>append</a> |item| to <var>result</var>.</p></li>
-  </ol>
-
- <li><p>Return <var>result</var>.</p></li>
-</ol>
-</div>
-
 <div algorithm=has-duplicates>
 To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
 

--- a/infra.bs
+++ b/infra.bs
@@ -1626,8 +1626,17 @@ below for <a for=set lt=append>ordered set append</a>, <a for=set>prepend</a>, a
 index is to add the given item to the list between the given index &minus; 1 and the given index. If
 the given index is 0, then <a for=list>prepend</a> the given item to the list.
 
-<p>To <dfn export for=list,set>remove</dfn> zero or more <a for=list>items</a> from a <a>list</a> is
-to remove all items from the list that match a given condition, or do nothing if none do.
+<div algorithm=remove>
+<p>To <dfn export for=list,set>remove</dfn> zero or more <a for=list>items</a> from a <a>list</a>:
+
+<ol>
+<li><p>Let |sizeBefore| be |list|'s <a for=list>size</a>.
+
+<li><p>Remove all items from the list that match a given condition, or do nothing if none do.
+
+<li><p>Return true if |list|'s <a for=list>size</a> is less than |sizeBefore|; otherwise false.
+</ol>
+</div>
 
 <div class=example id=example-list-remove>
  <p><a for=list>Removing</a> |x| from the <a>list</a> « |x|, |y|, |z|, |x| » is to remove all
@@ -1683,31 +1692,19 @@ following steps. They return a <a>list</a> of the same designation as |list|.
 </ol>
 </div>
 
-<div algorithm=porentially-remove>
-To <dfn export for=list,set>potentialy remove</dfn> zero or more <a for=list>items</a> from a <a>list</a> |list| based on a condition:
-
-<ol>
- <li><p>Let |sizeBefore| be |list|'s <a for=list>size</a>.
-
- <li><p><a for=list,set>Remove</a> the items from |list| based on the given condition.
-
- <li><p>Return true if |list|'s <a for=list>size</a> is less than |sizeBefore|; otherwise false.
-</ol>
-</div>
-
 <div algorithm=has-duplicates>
 To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
 
 <ol>
- <li><p>Let <var>result</var> be « ».
+ <li><p>Let <var>seenItems</var> be « ».
 
  <li>
   <p><a for=set>For each</a> |item| of <var>list</var>:
 
   <ol>
-   <li><p>If <var>result</var> <a for=list>contains</a> |item|, return true.</p></li>
+   <li><p>If <var>seenItems</var> <a for=list>contains</a> |item|, return true.</p></li>
 
-   <li><p><a for=list>Append</a> |item| to <var>result</var>.</p></li>
+   <li><p><a for=list>Append</a> |item| to <var>seenItems</var>.</p></li>
   </ol>
  </li>
 

--- a/infra.bs
+++ b/infra.bs
@@ -1718,7 +1718,7 @@ To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
  <li><p>Let <var>result</var> be « ».
 
  <li>
-  <p><a for=set>For each</a> |item| of <var>list</var>:</p>
+  <p><a for=set>For each</a> |item| of <var>list</var>:
 
   <ol>
    <li><p>If <var>result</var> <a for=list>contains</a> |item|, return true.</p></li>

--- a/infra.bs
+++ b/infra.bs
@@ -1683,6 +1683,50 @@ following steps. They return a <a>list</a> of the same designation as |list|.
 </ol>
 </div>
 
+<div algorithm=porentially-remove>
+To <dfn export for=list,set>potentialy remove</dfn> zero or more <a for=list>items</a> from a <a>list</a> |list| based on a condition, perform the following steps:
+
+<ol>
+ <li><p>If no item in |list| matches the given condition <a for=list,set>exists</a>, return false.
+
+ <li><p><a for=list,set>Remove</a> the items from |list|.
+
+ <li><p>Return true.
+</ol>
+</div>
+
+<div algorithm=remove-duplicates>
+To <dfn export for=list>remove duplicates</dfn> from a <a>list</a> <var>list</var>, perform the following steps:
+
+<ol>
+ <li><p>Let <var>result</var> be an empty <a>list</a>.
+
+ <li><p><a for=set>For each</a> |item| of <var>list</var>:
+
+  <ol>
+   <li><p>If <var>result</var> does not <a for=list>contain</a> |item|, <a for=list>append</a> |item| to <var>result</var>.</p></li>
+  </ol>
+
+ <li><p>Return <var>result</var>.</p></li>
+</ol>
+</div>
+
+<div algorithm=has-duplicates>
+To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>, perform the following steps:
+
+<ol>
+ <li><p>Let <var>result</var> be an empty <a>list</a>.
+
+ <li><p><a for=set>For each</a> |item| of <var>list</var>:
+
+  <ol>
+   <li><p>If <var>result</var> <a for=list>contains</a> |item|, return true.</p></li>
+  </ol>
+
+ <li><p>Return false.</p></li>
+</ol>
+</div>
+
 <p>To <dfn export for=list,stack,queue,set>clone</dfn> a <a>list</a> |list| is to return a
 <a for=list>slice</a> of |list|.
 

--- a/infra.bs
+++ b/infra.bs
@@ -1687,11 +1687,11 @@ following steps. They return a <a>list</a> of the same designation as |list|.
 To <dfn export for=list,set>potentialy remove</dfn> zero or more <a for=list>items</a> from a <a>list</a> |list| based on a condition:
 
 <ol>
- <li><p>If no item in |list| matches the given condition <a for=list,set>exists</a>, then return false.
+ <li><p>Let |sizeBefore| be |list|'s <a for=list>size</a>.
 
- <li><p><a for=list,set>Remove</a> the items from |list|.
+ <li><p><a for=list,set>Remove</a> the items from |list| based on the given condition.
 
- <li><p>Return true.
+ <li><p>Return true if |list|'s <a for=list>size</a> is less than |sizeBefore|, and false otherwise.
 </ol>
 </div>
 

--- a/infra.bs
+++ b/infra.bs
@@ -1722,6 +1722,7 @@ To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
 
   <ol>
    <li><p>If <var>result</var> <a for=list>contains</a> |item|, return true.</p></li>
+
    <li><p><a for=list>Append</a> |item| to <var>result</var>.</p></li>
   </ol>
  </li>

--- a/infra.bs
+++ b/infra.bs
@@ -1626,7 +1626,7 @@ below for <a for=set lt=append>ordered set append</a>, <a for=set>prepend</a>, a
 index is to add the given item to the list between the given index &minus; 1 and the given index. If
 the given index is 0, then <a for=list>prepend</a> the given item to the list.
 
-<div algorithm=remove>
+<div algorithm>
 <p>To <dfn export for=list,set>remove</dfn> zero or more <a for=list>items</a> from a <a>list</a>:
 
 <ol>

--- a/infra.bs
+++ b/infra.bs
@@ -1630,11 +1630,11 @@ the given index is 0, then <a for=list>prepend</a> the given item to the list.
 <p>To <dfn export for=list,set>remove</dfn> zero or more <a for=list>items</a> from a <a>list</a>:
 
 <ol>
-<li><p>Let |sizeBefore| be |list|'s <a for=list>size</a>.
+ <li><p>Let |sizeBefore| be |list|'s <a for=list>size</a>.
 
-<li><p>Remove all items from the list that match a given condition, or do nothing if none do.
+ <li><p>Remove all items from the list that match a given condition, or do nothing if none do.
 
-<li><p>Return true if |list|'s <a for=list>size</a> is less than |sizeBefore|; otherwise false.
+ <li><p>Return true if |list|'s <a for=list>size</a> is less than |sizeBefore|; otherwise false.
 </ol>
 </div>
 

--- a/infra.bs
+++ b/infra.bs
@@ -1693,7 +1693,7 @@ following steps. They return a <a>list</a> of the same designation as |list|.
 </div>
 
 <div algorithm>
-To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
+<p>To check if a <a>list</a> |list| <dfn export for=list>has duplicates</dfn>:
 
 <ol>
  <li><p>Let <var>seenItems</var> be « ».


### PR DESCRIPTION
These algorithms are currently defined in the sanitizer spec, and seem like they belong in infra instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/709.html" title="Last updated on May 7, 2026, 11:25 AM UTC (6fc6344)">Preview</a> | <a href="https://whatpr.org/infra/709/994009c...6fc6344.html" title="Last updated on May 7, 2026, 11:25 AM UTC (6fc6344)">Diff</a>