### PR TITLE
Define identity/equality operators

### DIFF
--- a/infra.bs
+++ b/infra.bs
@@ -2110,8 +2110,8 @@ a <a>map</a> |map|, with a less than algorithm |lessThanAlgo|, is to create a ne
  </ol>
 </div>
 
-<p>Two <a>structs</a> are <a>considered equal</a> given |context| if all of their corresponding <a
-for=struct>items</a> are <a for=/>equal</a> given |context|.
+<p>Two <a>structs</a> are <a>considered equal</a> given |context| if all of their corresponding
+<a for=struct>items</a> are <a for=/>equal</a> given |context|.
 
 <h4 id=tuples>Tuples</h4>
 

--- a/infra.bs
+++ b/infra.bs
@@ -706,6 +706,47 @@ Standard that should be reported and addressed.
  </ol>
 </div>
 
+<h3 id=equality>Equality</h3>
+
+<p>Two values the same data type can be <a>identical</a>, <dfn export lt="equal|equals|shallow
+equal">equal</dfn>, or <dfn export lt="equivalent|deep equal">equivalent</dfn>.
+
+<p>Variables or references are <dfn export lt=is|identical>identical</dfn> if they refer to the same
+value, or if they are both of the same primitive type, and that primitive type's definition of
+<a>identical</a> applies to them.
+
+<p>Unless stated otherwise, two values of the same type are <a for=/>equal</a> if they are also
+<a>identical</a>. A data type can be specified to relax that condition and have its own definition
+of <a for=/>equal</a>.
+
+<p>Unless stated otherwise, two values of the same type are <a>equivalent</a> if they are also <a
+for=/>equal</a>. A data type can be specified to relax that condition and have its own definition of
+<a>equivalent</a>.
+
+
+<div class=example id=example-struct-equality>
+ <ol>
+  <p>A <dfn ignore>keyValue</dfn> is an example <a>tuple</a> consisting of a <dfn ignore>key</dfn>
+  (a string) and <dfn ignore>value</dfn> (a <a for=/>list</a> of numbers).
+
+  <li><p>Let |original| be the keyValue ("x", « 1, 2, 3, 4 »). <li><p>Let |alsoOriginal| be
+  |original|. <li><p>Let |copyWithSharedList| be the keyValue ("x", |original|'s value). <li><p>Let
+  |clone| be ("x", « 1, 2, 3, 4 »). <li><p><a>Assert</a>: |original| <a for=/>is</a> |alsoOriginal|
+  (they are <a>identical</a>). <li><p><a>Assert</a>: |original| <a for=/>is</a> not
+  |copyWithSharedList|. <li><p><a>Assert</a>: |original| <a for=/>is</a> not |clone| (they are not
+  <a>identical</a>). <li><p><a>Assert</a>: |original| is <a for=/>equal</a> to |copyWithSharedList|.
+  <li><p><a>Assert</a>: |original| is not <a for=/>equal</a> to |clone|. <li><p><a>Assert</a>:
+  |original| is <a>equivalent</a> to |clone|.
+ </ol>
+</div>
+
+<div class=example id=example-list-equivalence>
+ <ol>
+  <li><p>Let |x| be « 1, « 2, 3 », 4 ». <li><p>Let |y| be « 1, « 2, 3 », 4 ». <li><p><a>Assert</a>:
+  |x| and |y| are not <a>identical</a>. <li><p><a>Assert</a>: |x| and |y| are not <a
+  for=/>equal</a>. <li><p><a>Assert</a>: |x| and |y| are <a>equivalent</a>.
+ </ol>
+</div>
 
 <h2 id=primitive-data-types>Primitive data types</h2>
 
@@ -718,6 +759,7 @@ JavaScript <b>null</b> value. [[!ECMA-262]]
 
 <p class=example id=example-null-return>If <var>input</var> is the empty string, then return null.
 
+<p>Null values are always <a>identical</a>.
 
 <h3 id=booleans>Booleans</h3>
 
@@ -725,6 +767,7 @@ JavaScript <b>null</b> value. [[!ECMA-262]]
 
 <p class=example id=example-boolean>Let <var ignore>elementSeen</var> be false.
 
+<p>Two <a>booleans</a> are <a>identical</a> when they are both true or both false.
 
 <h3 id=numbers>Numbers</h3>
 
@@ -766,6 +809,9 @@ more guidance here around types and mathematical operations. Help appreciated!
 <p>A <dfn export>64-bit signed integer</dfn> is an integer in the range &minus;9223372036854775808
 to 9223372036854775807 (&minus;2<sup>63</sup> to 2<sup>63</sup> &minus; 1), inclusive.
 
+<hr>
+
+<p>Two numbers are <a>identical</a> when they are the same underlying number.
 
 <h3 id=bytes>Bytes</h3>
 
@@ -784,7 +830,6 @@ section of <cite>ASCII format for Network Interchange</cite>, between parenthese
 
 <p class=example id=example-byte-notation>0x49 (I) when <a>UTF-8 decoded</a> becomes the
 <a>code point</a> U+0049 (I).
-
 
 <h3 id=byte-sequences>Byte sequences</h3>
 
@@ -815,6 +860,9 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 <p>A <a>byte sequence</a> <var>A</var> is a <dfn export>byte-case-insensitive</dfn> match for a
 <a>byte sequence</a> <var>B</var>, if the <a>byte-lowercase</a> of <var>A</var> is the
 <a>byte-lowercase</a> of <var>B</var>.
+
+<p>Two <a>byte sequences</a> are <a>identical</a> if their <a for="byte sequence">lengths</a> are
+<a>identical</a> and all of their <a>bytes</a> are <a>identical</a>.
 
 <hr>
 
@@ -1057,7 +1105,7 @@ where <a>UTF-8 encode</a> comes into play.
 
 <p>A <a>string</a> <var>a</var> <dfn export for=string lt="is|identical to">is</dfn> or is
 <a for=string>identical to</a> a <a>string</a> <var>b</var> if it consists of the same sequence of
-<a>code units</a>.
+<a>code units</a>. Those strings are considered <a>identical</a> for equality comparison.
 
 <p>Except where otherwise stated, all string comparisons use <a for=string>is</a>.
 
@@ -1592,6 +1640,9 @@ list multiple assignment syntax is used.
 
 <hr>
 
+<p>Two <a>lists</a> are <a>equivalent</a> if they have the same <a for=list>size</a> and all of
+their <a for=list>items</a> are <a>equivalent</a>.
+
 <p>To <dfn export for=list>append</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
 add the given <a for=list>item</a> to the end of the list.
 
@@ -1651,9 +1702,13 @@ the given index is 0, then <a for=list>prepend</a> the given item to the list.
 <p>To <dfn export for=list,stack,queue,set>empty</dfn> a <a>list</a> is to <a for=list>remove</a>
 all of its <a for=list>items</a>.
 
-<p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain|exist>contains</dfn> an
-<a for=list>item</a> if it appears in the list. We can also denote this by saying that, for a
-<a>list</a> |list| and an index |index|, "|list|[|index|] <a for=list>exists</a>".
+<p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain|exist>contains</dfn> an <a
+for=list>item</a> if the list has at least one item which <a>equals</a> that item. We can also
+denote this by saying that, for a <a>list</a> |list| and an index |index|, "|list|[|index|] <a
+for=list>exists</a>".
+
+<p>A <a>list</a> <dfn export for=list,stack,queue,set>contains an equivalent</dfn> of an <a
+for=list>item</a> if the list has at least one item which is <a>equivalent</a> to that item.
 
 <p>A <a>list</a>'s <dfn export for=list,stack,queue,set>size</dfn> is the number of
 <a for=list>items</a> the list <a for=list>contains</a>.
@@ -1835,11 +1890,22 @@ of either with <var>replacement</var> and <a for=set>remove</a> all other instan
 |superset| (and conversely, |superset| is a <dfn export for=set>superset</dfn> of |set|) if,
 <a for=list>for each</a> |item| of |set|, |superset| <a for=set>contains</a> |item|.
 
+<p>An <a>ordered set</a> |set| is a <dfn export for=set>equivalent subset</dfn> of another
+<a>ordered set</a> |superset| (and conversely, |superset| is a <dfn export for=set>equivalent
+superset</dfn> of |set|) if, <a for=list>for each</a> |item| of |set|, |superset| <a
+for=set>contains an equivalent</a> of |item|.
+
 <p class=note>This implies that an <a>ordered set</a> is both a <a for=set>subset</a> and a
 <a for=set>superset</a> of itself.
 
-<p>A [=/set=] |A| is <dfn export for=set>equal</dfn> to a [=/set=] |B|
-if |A| is a [=subset=] of |B| and |A| is a [=superset=] of |B|.
+<p>A [=/set=] |A| is <dfn export for=set lt=equal>unordered equal</dfn> to a [=/set=] |B| if |A| is
+a [=subset=] of |B| and |A| is a [=superset=] of |B|.
+
+<p>A [=/set=] |A| is <a>equivalent</a> to a [=/set=] |B| if |A| is an [=equivalent subset=] of |B|
+and |B| is an [=equivalent subset=] of |B|.
+
+<p>A [=/set=] |A| is <a for=/>equal</a> to a [=/set=] |B| if |A| is a [=subset=] of |B| and |B| is a
+[=subset=] of |A|.
 
 <p>The <dfn export for=set>intersection</dfn> of <a>ordered sets</a> |A| and |B|, is the result
 of creating a new <a>ordered set</a> |set| and, <a for=list>for each</a> |item| of |A|, if |B|
@@ -1889,6 +1955,16 @@ entries with a comma.
 |example|["<code>a</code>"] is the <a>byte sequence</a> `<code>x</code>`.
 
 <hr>
+
+<p>Two <a for=/>maps</a> <var>A</var> and <var>B</var> are the <dfn export>unordered
+equivalent</dfn> of each other if <var>A</var>'s <a for=map>size</a> is <var>B</var>'s <a
+for=map>size</a>, and <a for=list>for each</a> <a for=map>key</a> <var>k</var> in <var>A</var>,
+<var>A</var>[<var>k</var>] is <a>equivalent</a> to <var>B</var>[<var>k</var>].
+
+<p>Two <a for=/>maps</a> <var>A</var> and <var>B</var> are <a>equivalent</a> if <var>A</var>'s <a
+for=map>keys</a> and <var>B</var>'s <a for=map>keys</a> are <a>equivalent</a>, and for every <a
+for=map>key</a> <var>k</var> in <var>A</var>, <var>A</var>[<var>k</var>] is <a>equivalent</a> to
+<var>B</var>[<var>k</var>].
 
 <p>To <dfn export for=map lt="get|get the value">get the value of an entry</dfn> in an
 <a>ordered map</a> <var>map</var> given a <a for=map>key</a> <var>key</var> and an optional
@@ -2005,6 +2081,12 @@ a <a>map</a> |map|, with a less than algorithm |lessThanAlgo|, is to create a ne
   <li>&hellip;
  </ol>
 </div>
+
+<p>Two <a>structs</a> are <a for=/>equal</a> if all of their corresponding <a for=struct>items</a>
+are <a for=/>equal</a>.
+
+<p>Two <a>structs</a> are <a for=/>equivalent</a> if all of their corresponding <a
+for=struct>items</a> are <a>equivalent</a>.
 
 <h4 id=tuples>Tuples</h4>
 

--- a/infra.bs
+++ b/infra.bs
@@ -726,7 +726,7 @@ compare them in that way must [=assert=].
   ignore>key</dfn> (a string) and <dfn ignore>value</dfn> (a <a for=/>list</a> of numbers).
 
   <li><p>Let |original| be the keyValue ("x", « 1, 2, 3, 4 »).
-  
+
   <li><p>Let |alsoOriginal| be |original|. <li><p>Let |copyWithSharedList| be the keyValue ("x",
   |original|'s value). <li><p>Let |clone| be ("x", « 1, 2, 3, 4 »).
 

--- a/infra.bs
+++ b/infra.bs
@@ -727,8 +727,11 @@ compare them in that way must [=assert=].
 
   <li><p>Let |original| be the keyValue ("x", « 1, 2, 3, 4 »).
 
-  <li><p>Let |alsoOriginal| be |original|. <li><p>Let |copyWithSharedList| be the keyValue ("x",
-  |original|'s value). <li><p>Let |clone| be ("x", « 1, 2, 3, 4 »).
+  <li><p>Let |alsoOriginal| be |original|.
+
+  <li><p>Let |copyWithSharedList| be the keyValue ("x", |original|'s value).
+
+  <li><p>Let |clone| be ("x", « 1, 2, 3, 4 »).
 
   <li><p><a>Assert</a>: |original| <a for=/>is</a> |alsoOriginal|.
 

--- a/infra.bs
+++ b/infra.bs
@@ -747,11 +747,11 @@ check</a> does not contain cyclic references.</p>
  </ol>
 </div>
 
-<p>An <dfn>equality context</dfn> is an object used for book keeping when performing equality checks.</p>
+<p>An <dfn>equality context</dfn> is an object used for book keeping when performing equality
+checks.</p>
 
-<p>An <a>equality context</a> has an associated <a for=/>list</a> <dfn for="equality context">visited items</dfn>, initially « ».</p></li>
- a <a for=/>list</a>, representing values visited when checking
-for equality.</p>
+<p>An <a>equality context</a> has an associated <a for=/>list</a> <dfn for="equality
+context">visited items</dfn>, initially « ».</p>
 
 <div algorithm>
 <p>To check if <var>A</var> and <var>B</var> are <dfn export>equal</dfn> given an optional
@@ -761,8 +761,9 @@ for equality.</p>
 
   <li><p>If <var>A</var> is <a for=/>identical to</a> <var>B</var>, then return true.</p></li>
 
-  <li><p><a>Assert</a>: There is no item in <var>context</var>'s <a for="equality context">visited items</a>'s <a for=list>items</a> who <a
-  for=/>is</a> either <var>A</var> or <var>B</var>.</p></li>
+  <li><p><a>Assert</a>: There is no item in <var>context</var>'s <a for="equality context">visited
+  items</a>'s <a for=list>items</a> who <a for=/>is</a> either <var>A</var> or
+  <var>B</var>.</p></li>
 
   <li><p><a for=list>Append</a> <var>A</var> to <var>context</var>.</p></li>
 

--- a/infra.bs
+++ b/infra.bs
@@ -879,6 +879,7 @@ section of <cite>ASCII format for Network Interchange</cite>, between parenthese
 <p class=example id=example-byte-notation>0x49 (I) when <a>UTF-8 decoded</a> becomes the
 <a>code point</a> U+0049 (I).
 
+
 <h3 id=byte-sequences>Byte sequences</h3>
 
 <p>A <dfn export>byte sequence</dfn> is a sequence of <a>bytes</a>, represented as a space-separated

--- a/infra.bs
+++ b/infra.bs
@@ -708,43 +708,37 @@ Standard that should be reported and addressed.
 
 <h3 id=equality>Equality</h3>
 
-<p>Two values the same data type can be <a>identical</a>, <dfn export lt="equal|equals|shallow
-equal">equal</dfn>, or <dfn export lt="equivalent|deep equal">equivalent</dfn>.
+<p>Two values the same data type can be <a for=/>identical to</a> each other or <dfn export
+lt="equal|equals|shallow equal">equal</dfn>.
 
-<p>Variables or references are <dfn export lt=is|identical>identical</dfn> if they refer to the same
-value, or if they are both of the same primitive type, and that primitive type's definition of
-<a>identical</a> applies to them.
+<p>Variables or references are <dfn export>identical to</dfn> each other if they refer to the same
+value, or if they are both of the same primitive type, and that primitive type's definition of <a
+for=/>identical to</a> applies to them. A variable <dfn export>is</dfn> another variable when theh
+are <a for=/>identical to</a> each other.
 
-<p>Unless stated otherwise, two values of the same type are <a for=/>equal</a> if they are also
-<a>identical</a>. A data type can be specified to relax that condition and have its own definition
-of <a for=/>equal</a>.
-
-<p>Unless stated otherwise, two values of the same type are <a>equivalent</a> if they are also <a
-for=/>equal</a>. A data type can be specified to relax that condition and have its own definition of
-<a>equivalent</a>.
-
+<p>Primitive data types are <a for=/>equal</a> if they are also <a for=/>identical to</a> each
+other. Other data types must provide their own definition of <a for=/>equal</a>; Otherwise trying to
+compare them in that way must [=assert=].
 
 <div class=example id=example-struct-equality>
  <ol>
-  <p>A <dfn ignore>keyValue</dfn> is an example <a>tuple</a> consisting of a <dfn ignore>key</dfn>
-  (a string) and <dfn ignore>value</dfn> (a <a for=/>list</a> of numbers).
+  <li><p>A <dfn ignore>keyValue</dfn> is an example <a>tuple</a> consisting of a <dfn
+  ignore>key</dfn> (a string) and <dfn ignore>value</dfn> (a <a for=/>list</a> of numbers).
 
-  <li><p>Let |original| be the keyValue ("x", « 1, 2, 3, 4 »). <li><p>Let |alsoOriginal| be
-  |original|. <li><p>Let |copyWithSharedList| be the keyValue ("x", |original|'s value). <li><p>Let
-  |clone| be ("x", « 1, 2, 3, 4 »). <li><p><a>Assert</a>: |original| <a for=/>is</a> |alsoOriginal|
-  (they are <a>identical</a>). <li><p><a>Assert</a>: |original| <a for=/>is</a> not
-  |copyWithSharedList|. <li><p><a>Assert</a>: |original| <a for=/>is</a> not |clone| (they are not
-  <a>identical</a>). <li><p><a>Assert</a>: |original| is <a for=/>equal</a> to |copyWithSharedList|.
-  <li><p><a>Assert</a>: |original| is not <a for=/>equal</a> to |clone|. <li><p><a>Assert</a>:
-  |original| is <a>equivalent</a> to |clone|.
- </ol>
-</div>
+  <li><p>Let |original| be the keyValue ("x", « 1, 2, 3, 4 »).
+  
+  <li><p>Let |alsoOriginal| be |original|. <li><p>Let |copyWithSharedList| be the keyValue ("x",
+  |original|'s value). <li><p>Let |clone| be ("x", « 1, 2, 3, 4 »).
 
-<div class=example id=example-list-equivalence>
- <ol>
-  <li><p>Let |x| be « 1, « 2, 3 », 4 ». <li><p>Let |y| be « 1, « 2, 3 », 4 ». <li><p><a>Assert</a>:
-  |x| and |y| are not <a>identical</a>. <li><p><a>Assert</a>: |x| and |y| are not <a
-  for=/>equal</a>. <li><p><a>Assert</a>: |x| and |y| are <a>equivalent</a>.
+  <li><p><a>Assert</a>: |original| <a for=/>is</a> |alsoOriginal|. 
+
+  <li><p><a>Assert</a>: |original| is <a for=/>identical to</a> |alsoOriginal|. 
+
+  <li><p><a>Assert</a>: |original| <a for=/>is</a> not |clone|.
+
+  <li><p><a>Assert</a>: |original| <a for=/>is</a> not |copyWithSharedList|.
+
+  <li><p><a>Assert</a>: |original| is <a for=/>equal</a> to |copyWithSharedList|.
  </ol>
 </div>
 
@@ -759,7 +753,7 @@ JavaScript <b>null</b> value. [[!ECMA-262]]
 
 <p class=example id=example-null-return>If <var>input</var> is the empty string, then return null.
 
-<p>Null values are always <a>identical</a>.
+<p>Null values are always <a for=/>identical to</a> each other.
 
 <h3 id=booleans>Booleans</h3>
 
@@ -767,7 +761,8 @@ JavaScript <b>null</b> value. [[!ECMA-262]]
 
 <p class=example id=example-boolean>Let <var ignore>elementSeen</var> be false.
 
-<p>Two <a>booleans</a> are <a>identical</a> when they are both true or both false.
+<p>Two <a>booleans</a> are <a for=/>identical to</a> each other when they are both true or both
+false.
 
 <h3 id=numbers>Numbers</h3>
 
@@ -811,7 +806,7 @@ to 9223372036854775807 (&minus;2<sup>63</sup> to 2<sup>63</sup> &minus; 1), incl
 
 <hr>
 
-<p>Two numbers are <a>identical</a> when they are the same underlying number.
+<p>Two numbers are <a for=/>identical to</a> each other when they are the same underlying number.
 
 <h3 id=bytes>Bytes</h3>
 
@@ -861,8 +856,9 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 <a>byte sequence</a> <var>B</var>, if the <a>byte-lowercase</a> of <var>A</var> is the
 <a>byte-lowercase</a> of <var>B</var>.
 
-<p>Two <a>byte sequences</a> are <a>identical</a> if their <a for="byte sequence">lengths</a> are
-<a>identical</a> and all of their <a>bytes</a> are <a>identical</a>.
+<p>Two <a>byte sequences</a> are <a for=/>identical to</a> each other if their <a for="byte
+sequence">lengths</a> are <a for=/>identical to</a> each other and all of their <a>bytes</a> are <a
+for=/>identical to</a> each other.
 
 <hr>
 
@@ -1105,7 +1101,8 @@ where <a>UTF-8 encode</a> comes into play.
 
 <p>A <a>string</a> <var>a</var> <dfn export for=string lt="is|identical to">is</dfn> or is
 <a for=string>identical to</a> a <a>string</a> <var>b</var> if it consists of the same sequence of
-<a>code units</a>. Those strings are considered <a>identical</a> for equality comparison.
+<a>code units</a>. Those strings are considered <a for=/>identical to</a> each other for equality
+comparison.
 
 <p>Except where otherwise stated, all string comparisons use <a for=string>is</a>.
 
@@ -1640,9 +1637,6 @@ list multiple assignment syntax is used.
 
 <hr>
 
-<p>Two <a>lists</a> are <a>equivalent</a> if they have the same <a for=list>size</a> and all of
-their <a for=list>items</a> are <a>equivalent</a>.
-
 <p>To <dfn export for=list>append</dfn> to a <a>list</a> that is not an <a>ordered set</a> is to
 add the given <a for=list>item</a> to the end of the list.
 
@@ -1707,9 +1701,6 @@ for=list>item</a> if the list has at least one item which <a>equals</a> that ite
 denote this by saying that, for a <a>list</a> |list| and an index |index|, "|list|[|index|] <a
 for=list>exists</a>".
 
-<p>A <a>list</a> <dfn export for=list,stack,queue,set>contains an equivalent</dfn> of an <a
-for=list>item</a> if the list has at least one item which is <a>equivalent</a> to that item.
-
 <p>A <a>list</a>'s <dfn export for=list,stack,queue,set>size</dfn> is the number of
 <a for=list>items</a> the list <a for=list>contains</a>.
 
@@ -1724,6 +1715,9 @@ its <a for=list>size</a> is zero.
 set of steps on each <a for=list>item</a> in order, use phrasing of the form
 "<a for=list>For each</a> |item| of <var ignore>list</var>", and then operate on |item| in the
 subsequent prose.
+
+<p>A [=/list=] |A| is <a for=/>equal</a> to a [=/list=] |B| if |A| has the same size as |B| and
+|A|[|i|] is <a for=/>equal</a> to |B|[|i|] for all [=indices=] |i| of |A|.
 
 <div algorithm=slice>
 <p>To <dfn export for=list,stack,queue,set>slice</dfn> a <a>list</a> |list|, with an optional
@@ -1890,19 +1884,11 @@ of either with <var>replacement</var> and <a for=set>remove</a> all other instan
 |superset| (and conversely, |superset| is a <dfn export for=set>superset</dfn> of |set|) if,
 <a for=list>for each</a> |item| of |set|, |superset| <a for=set>contains</a> |item|.
 
-<p>An <a>ordered set</a> |set| is an <dfn export for=set>equivalent subset</dfn> of another
-<a>ordered set</a> |superset| (and conversely, |superset| is an <dfn export for=set>equivalent
-superset</dfn> of |set|) if, <a for=list>for each</a> |item| of |set|, |superset| <a
-for=set>contains an equivalent</a> of |item|.
-
 <p class=note>This implies that an <a>ordered set</a> is both a <a for=set>subset</a> and a
 <a for=set>superset</a> of itself.
 
 <p>A [=/set=] |A| is <dfn export for=set lt=equal>unordered equal</dfn> to a [=/set=] |B| if |A| is
 a [=subset=] of |B| and |A| is a [=superset=] of |B|.
-
-<p>A [=/set=] |A| is <a>equivalent</a> to a [=/set=] |B| if |A| is an [=equivalent subset=] of |B|
-and |B| is an [=equivalent subset=] of |B|.
 
 <p>A [=/set=] |A| is <a for=/>equal</a> to a [=/set=] |B| if |A| is a [=subset=] of |B| and |B| is a
 [=subset=] of |A|.
@@ -1939,9 +1925,8 @@ creates a new <a>ordered set</a> containing all of the integers from <var>n</var
 
 <p>An <dfn export lt="ordered map|map">ordered map</dfn>, or sometimes just "map", is a
 specification type consisting of a finite ordered sequence of <a for=/>tuples</a>, each consisting
-of a <dfn for=map export>key</dfn> and a <dfn for=map export>value</dfn>, with no key appearing
-twice. Each such tuple is called an <dfn for=map export>entry</dfn>.
-<!-- TODO: we have to define key equality for this to be truly sound. -->
+of a <dfn for=map export>key</dfn> and a <dfn for=map export>value</dfn>, with no two keys being <a
+for=/>equal</a>. Each such tuple is called an <dfn for=map export>entry</dfn>.
 
 <p class=note>As with <a>ordered sets</a>, by default we assume that maps need to be ordered for
 interoperability among implementations.
@@ -1955,16 +1940,6 @@ entries with a comma.
 |example|["<code>a</code>"] is the <a>byte sequence</a> `<code>x</code>`.
 
 <hr>
-
-<p>Two <a for=/>maps</a> <var>A</var> and <var>B</var> are the <dfn export>unordered
-equivalent</dfn> of each other if <var>A</var>'s <a for=map>size</a> is <var>B</var>'s <a
-for=map>size</a>, and <a for=list>for each</a> <a for=map>key</a> <var>k</var> in <var>A</var>,
-<var>A</var>[<var>k</var>] is <a>equivalent</a> to <var>B</var>[<var>k</var>].
-
-<p>Two <a for=/>maps</a> <var>A</var> and <var>B</var> are <a>equivalent</a> if <var>A</var>'s <a
-for=map>keys</a> and <var>B</var>'s <a for=map>keys</a> are <a>equivalent</a>, and for every <a
-for=map>key</a> <var>k</var> in <var>A</var>, <var>A</var>[<var>k</var>] is <a>equivalent</a> to
-<var>B</var>[<var>k</var>].
 
 <p>To <dfn export for=map lt="get|get the value">get the value of an entry</dfn> in an
 <a>ordered map</a> <var>map</var> given a <a for=map>key</a> <var>key</var> and an optional
@@ -2033,6 +2008,9 @@ a set of steps on each <a for=map>entry</a> in order, use phrasing of the form
 "<a for=map>For each</a> |key| → |value| of |map|", and then operate on |key| and |value| in the
 subsequent prose.
 
+<p>Two <a for=/>maps</a> are considered <a for=/>equal</a> when their <a for=map>entry</a> lists are
+<a for=/>equal</a>.
+
 <p>To <dfn export for=map>clone</dfn> an <a>ordered map</a> |map| is to create a new
 <a>ordered map</a> |clone|, and, <a for=map>for each</a> |key| → |value| of |map|,
 <a for=map>set</a> |clone|[|key|] to |value|.
@@ -2084,9 +2062,6 @@ a <a>map</a> |map|, with a less than algorithm |lessThanAlgo|, is to create a ne
 
 <p>Two <a>structs</a> are <a for=/>equal</a> if all of their corresponding <a for=struct>items</a>
 are <a for=/>equal</a>.
-
-<p>Two <a>structs</a> are <a for=/>equivalent</a> if all of their corresponding <a
-for=struct>items</a> are <a>equivalent</a>.
 
 <h4 id=tuples>Tuples</h4>
 

--- a/infra.bs
+++ b/infra.bs
@@ -747,19 +747,22 @@ check</a> does not contain cyclic references.</p>
  </ol>
 </div>
 
-<p>An <dfn>equality context</dfn> is a <a for=/>list</a>, representing values visited when checking
+<p>An <dfn>equality context</dfn> is an object used for book keeping when performing equality checks.</p>
+
+<p>An <a>equality context</a> has an associated <a for=/>list</a> <dfn for="equality context">visited items</dfn>, initially « ».</p></li>
+ a <a for=/>list</a>, representing values visited when checking
 for equality.</p>
 
 <div algorithm>
 <p>To check if <var>A</var> and <var>B</var> are <dfn export>equal</dfn> given an optional
-<a>equality context</a> <var>context</var> (default « »):
+<a>equality context</a> <var>context</var> (default a new <a>equality context</a>):
  <ol>
   <li><p>If <var>A</var> and <var>B</var> are not of the same data type, then return false.</p></li>
 
   <li><p>If <var>A</var> is <a for=/>identical to</a> <var>B</var>, then return true.</p></li>
 
-  <li><p><a>Assert</a>: There is no item in <var>context</var>'s <a for=list>items</a> who is <a
-  for=/>identical to</a> either <var>A</var> or <var>B</var>.</p></li>
+  <li><p><a>Assert</a>: There is no item in <var>context</var>'s <a for="equality context">visited items</a>'s <a for=list>items</a> who <a
+  for=/>is</a> either <var>A</var> or <var>B</var>.</p></li>
 
   <li><p><a for=list>Append</a> <var>A</var> to <var>context</var>.</p></li>
 

--- a/infra.bs
+++ b/infra.bs
@@ -1749,10 +1749,10 @@ the given index is 0, then <a for=list>prepend</a> the given item to the list.
 <p>To <dfn export for=list,stack,queue,set>empty</dfn> a <a>list</a> is to <a for=list>remove</a>
 all of its <a for=list>items</a>.
 
-<p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain|exist>contains</dfn> an <a
-for=list>item</a> if the list has at least one item which <a for=/>equals</a> that item. We can also
-denote this by saying that, for a <a>list</a> |list| and an index |index|, "|list|[|index|] <a
-for=list>exists</a>".
+<p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain|exist>contains</dfn> an
+<a for=list>item</a> if the list has at least one item which <a for=/>equals</a> that item. We can also
+denote this by saying that, for a <a>list</a> |list| and an index |index|, "|list|[|index|]
+<a for=list>exists</a>".
 
 <p>A <a>list</a>'s <dfn export for=list,stack,queue,set>size</dfn> is the number of
 <a for=list>items</a> the list <a for=list>contains</a>.
@@ -1975,8 +1975,8 @@ creates a new <a>ordered set</a> containing all of the integers from <var>n</var
 
 <p>An <dfn export lt="ordered map|map">ordered map</dfn>, or sometimes just "map", is a
 specification type consisting of a finite ordered sequence of <a for=/>tuples</a>, each consisting
-of a <dfn for=map export>key</dfn> and a <dfn for=map export>value</dfn>, with no two keys being <a
-for=/>equal</a>. Each such tuple is called an <dfn for=map export>entry</dfn>.
+of a <dfn for=map export>key</dfn> and a <dfn for=map export>value</dfn>, with no two keys being
+<a for=/>equal</a>. Each such tuple is called an <dfn for=map export>entry</dfn>.
 
 <p class=note>As with <a>ordered sets</a>, by default we assume that maps need to be ordered for
 interoperability among implementations.

--- a/infra.bs
+++ b/infra.bs
@@ -771,7 +771,13 @@ context">visited items</dfn>, initially « ».</p>
 
  <li><p><a for=list>Append</a> |B| to |context|'s <a for="equality context">visited items</a>.
 
- <li><p>Return the result of the <a>equality check</a> given |A|, |B|, and |context|.
+ <li><p>Let |result| be the result of the <a>equality check</a> given |A|, |B|, and |context|.
+
+ <li><p><a for=list>Remove</a> |A| from |context|'s <a for="equality context">visited items</a>.
+
+ <li><p><a for=list>Remove</a> |B| from |context|'s <a for="equality context">visited items</a>.
+
+ <li><p>Return |result|.
 </ol>
 </div>
 

--- a/infra.bs
+++ b/infra.bs
@@ -708,7 +708,7 @@ Standard that should be reported and addressed.
 
 <h3 id=equality>Equality</h3>
 
-<p>Two values the same data type can be <a for=/>equal</a> or <a for=/>identical to</a> each
+<p>Two values of the same data type can be <a for=/>equal</a> or <a for=/>identical to</a> each
 other.</p>
 
 <p>Primitive data types define an <dfn export lt="considered identical|identity check">identity
@@ -724,14 +724,14 @@ check</a> does not contain cyclic references.</p>
 
 <div class=example id=example-struct-equality>
  <ol>
-  <li><p>A <dfn ignore>keyValue</dfn> is an example <a>tuple</a> consisting of a <dfn
-  ignore>key</dfn> (a string) and <dfn ignore>value</dfn> (a <a for=/>list</a> of numbers).
+  <li><p>A <dfn ignore>key value</dfn> is an example <a>tuple</a> consisting of a <dfn
+  ignore>key</dfn> (a string) and a <dfn ignore>value</dfn> (a <a for=/>list</a> of numbers).
 
-  <li><p>Let |original| be the keyValue ("x", « 1, 2, 3, 4 »).
+  <li><p>Let |original| be the key value ("x", « 1, 2, 3, 4 »).
 
   <li><p>Let |alsoOriginal| be |original|.
 
-  <li><p>Let |copyWithSharedList| be the keyValue ("x", |original|'s value).
+  <li><p>Let |copyWithSharedList| be the key value ("x", |original|'s value).
 
   <li><p>Let |clone| be ("x", « 1, 2, 3, 4 »).
 
@@ -747,47 +747,49 @@ check</a> does not contain cyclic references.</p>
  </ol>
 </div>
 
-<p>An <dfn>equality context</dfn> is an object used for book keeping when performing equality
+<p>An <dfn>equality context</dfn> is an object used for bookkeeping when performing equality
 checks.</p>
 
 <p>An <a>equality context</a> has an associated <a for=/>list</a> <dfn for="equality
 context">visited items</dfn>, initially « ».</p>
 
 <div algorithm>
-<p>To check if <var>A</var> and <var>B</var> are <dfn export>equal</dfn> given an optional
-<a>equality context</a> <var>context</var> (default a new <a>equality context</a>):
- <ol>
-  <li><p>If <var>A</var> and <var>B</var> are not of the same data type, then return false.
+<p>To check if |A| and |B| are <dfn export>equal</dfn> given an optional
+<a>equality context</a> |context| (default a new <a>equality context</a>):
+<ol>
+ <li><p>If |A| and |B| are not of the same data type, then return false.
 
-  <li><p>If <var>A</var> is <a for=/>identical to</a> <var>B</var>, then return true.
+ <li><p>If |A| is <a for=/>identical to</a> |B|, then return true.
 
-  <li><p><a>Assert</a>: There is no item in <var>context</var>'s <a for="equality context">visited
-  items</a>'s <a for=list>items</a> who <a for=/>is</a> either <var>A</var> or
-  <var>B</var>.
+ <li><p>If the common data type of |A| and |B| does not define an <a>equality
+ check</a>, then return false.
 
-  <li><p><a for=list>Append</a> <var>A</var> to <var>context</var>.
+ <li><p><a>Assert</a>: There is no item in |context|'s <a for="equality context">visited
+ items</a> that <a for=/>is</a> either |A| or |B|.
 
-  <li><p><a for=list>Append</a> <var>B</var> to <var>context</var>.
+ <li><p><a for=list>Append</a> |A| to |context|'s <a for="equality context">visited items</a>.
 
-  <li><p>Return the result of the <a>equality check</a> given <var>A</var> and
-  <var>B</var>.
- </ol>
+ <li><p><a for=list>Append</a> |B| to |context|'s <a for="equality context">visited items</a>.
+
+ <li><p>Return the result of the <a>equality check</a> given |A|, |B|, and
+ |context|.
+</ol>
 </div>
 
 <div algorithm=identity-check>
-<p>To check if <var>A</var> is <dfn export>identical to</dfn> <var>B</var> (<var>A</var> <dfn
-export>is</dfn> <var>B</var>):
+<p>To check if |A| is <dfn export>identical to</dfn> |B| (|A| <dfn
+export>is</dfn> |B|):
 <ol>
- <li><p>If <var>A</var> and <var>B</var> are not of the same type, then return false.
+ <li><p>If |A| and |B| are not of the same data type, then return false.
 
- <li><p>If <var>A</var> and <var>B</var> are references to the same value, then return
+ <li><p>If |A| and |B| are references to the same value, then return
  true.
 
- <li><p>If the common type of <var>A</var> and <var>B</var> does not define an <a>identity
+ <li><p>If the common data type of |A| and |B| does not define an <a>identity
  check</a>, then return false.
 
- <li><p>Return the result of the type-specific <a>identity check</a> given <var>A</var> and
- <var>B</var>.
+ <li><p>Return the result of the type-specific <a>identity check</a> given |A| and
+ |B|.
 </ol>
 </div>
 
@@ -855,7 +857,7 @@ to 9223372036854775807 (&minus;2<sup>63</sup> to 2<sup>63</sup> &minus; 1), incl
 
 <hr>
 
-<p>Two numbers are <a>considered identical</a> when they are the same underlying number.
+<p>Two numbers are <a for=/>considered identical</a> when they are the same underlying number.
 
 <h3 id=bytes>Bytes</h3>
 
@@ -905,7 +907,7 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 <a>byte sequence</a> <var>B</var>, if the <a>byte-lowercase</a> of <var>A</var> is the
 <a>byte-lowercase</a> of <var>B</var>.
 
-<p>Two <a>byte sequences</a> are <a>considered identical</a> if their <a for="byte
+<p>Two <a>byte sequences</a> are <a for=/>considered identical</a> if their <a for="byte
 sequence">lengths</a> are <a for=/>identical to</a> each other and all of their <a>bytes</a> are <a
 for=/>identical to</a> each other.
 
@@ -1764,7 +1766,7 @@ set of steps on each <a for=list>item</a> in order, use phrasing of the form
 "<a for=list>For each</a> |item| of <var ignore>list</var>", and then operate on |item| in the
 subsequent prose.
 
-<p>To [=Lists=] |A| and |B| are <a>considered equal</a> given |context| if |A| has the same size as
+<p>Two lists |A| and |B| are <a>considered equal</a> given |context| if |A| has the same size as
 |B| and |A|[|i|] is <a for=/>equal</a> to |B|[|i|] given |context| for all [=indices=] |i| of |A|.
 
 <div algorithm=slice>

--- a/infra.bs
+++ b/infra.bs
@@ -730,9 +730,9 @@ compare them in that way must [=assert=].
   <li><p>Let |alsoOriginal| be |original|. <li><p>Let |copyWithSharedList| be the keyValue ("x",
   |original|'s value). <li><p>Let |clone| be ("x", « 1, 2, 3, 4 »).
 
-  <li><p><a>Assert</a>: |original| <a for=/>is</a> |alsoOriginal|. 
+  <li><p><a>Assert</a>: |original| <a for=/>is</a> |alsoOriginal|.
 
-  <li><p><a>Assert</a>: |original| is <a for=/>identical to</a> |alsoOriginal|. 
+  <li><p><a>Assert</a>: |original| is <a for=/>identical to</a> |alsoOriginal|.
 
   <li><p><a>Assert</a>: |original| <a for=/>is</a> not |clone|.
 

--- a/infra.bs
+++ b/infra.bs
@@ -747,7 +747,7 @@ check</a> does not contain cyclic references.</p>
  </ol>
 </div>
 
-<p>A <dfn>equality context</dfn> is a <a for=/>list</a>, representing values visited when checking
+<p>An <dfn>equality context</dfn> is a <a for=/>list</a>, representing values visited when checking
 for equality.</p>
 
 <div algorithm>

--- a/infra.bs
+++ b/infra.bs
@@ -1890,7 +1890,7 @@ of either with <var>replacement</var> and <a for=set>remove</a> all other instan
 |superset| (and conversely, |superset| is a <dfn export for=set>superset</dfn> of |set|) if,
 <a for=list>for each</a> |item| of |set|, |superset| <a for=set>contains</a> |item|.
 
-<p>An <a>ordered set</a> |set| is a <dfn export for=set>equivalent subset</dfn> of another
+<p>An <a>ordered set</a> |set| is an <dfn export for=set>equivalent subset</dfn> of another
 <a>ordered set</a> |superset| (and conversely, |superset| is a <dfn export for=set>equivalent
 superset</dfn> of |set|) if, <a for=list>for each</a> |item| of |set|, |superset| <a
 for=set>contains an equivalent</a> of |item|.

--- a/infra.bs
+++ b/infra.bs
@@ -757,20 +757,20 @@ context">visited items</dfn>, initially « ».</p>
 <p>To check if <var>A</var> and <var>B</var> are <dfn export>equal</dfn> given an optional
 <a>equality context</a> <var>context</var> (default a new <a>equality context</a>):
  <ol>
-  <li><p>If <var>A</var> and <var>B</var> are not of the same data type, then return false.</p></li>
+  <li><p>If <var>A</var> and <var>B</var> are not of the same data type, then return false.
 
-  <li><p>If <var>A</var> is <a for=/>identical to</a> <var>B</var>, then return true.</p></li>
+  <li><p>If <var>A</var> is <a for=/>identical to</a> <var>B</var>, then return true.
 
   <li><p><a>Assert</a>: There is no item in <var>context</var>'s <a for="equality context">visited
   items</a>'s <a for=list>items</a> who <a for=/>is</a> either <var>A</var> or
-  <var>B</var>.</p></li>
+  <var>B</var>.
 
-  <li><p><a for=list>Append</a> <var>A</var> to <var>context</var>.</p></li>
+  <li><p><a for=list>Append</a> <var>A</var> to <var>context</var>.
 
-  <li><p><a for=list>Append</a> <var>B</var> to <var>context</var>.</p></li>
+  <li><p><a for=list>Append</a> <var>B</var> to <var>context</var>.
 
   <li><p>Return the result of the <a>equality check</a> given <var>A</var> and
-  <var>B</var>.</p></li>
+  <var>B</var>.
  </ol>
 </div>
 
@@ -778,16 +778,16 @@ context">visited items</dfn>, initially « ».</p>
 <p>To check if <var>A</var> is <dfn export>identical to</dfn> <var>B</var> (<var>A</var> <dfn
 export>is</dfn> <var>B</var>):
 <ol>
- <li><p>If <var>A</var> and <var>B</var> are not of the same type, then return false.</p></li>
+ <li><p>If <var>A</var> and <var>B</var> are not of the same type, then return false.
 
  <li><p>If <var>A</var> and <var>B</var> are references to the same value, then return
- true.</p></li>
+ true.
 
  <li><p>If the common type of <var>A</var> and <var>B</var> does not define an <a>identity
- check</a>, then return false.</p></li>
+ check</a>, then return false.
 
  <li><p>Return the result of the type-specific <a>identity check</a> given <var>A</var> and
- <var>B</var>.</p></li>
+ <var>B</var>.
 </ol>
 </div>
 

--- a/infra.bs
+++ b/infra.bs
@@ -713,7 +713,7 @@ lt="equal|equals|shallow equal">equal</dfn>.
 
 <p>Variables or references are <dfn export>identical to</dfn> each other if they refer to the same
 value, or if they are both of the same primitive type, and that primitive type's definition of <a
-for=/>identical to</a> applies to them. A variable <dfn export>is</dfn> another variable when theh
+for=/>identical to</a> applies to them. A variable <dfn export>is</dfn> another variable when they
 are <a for=/>identical to</a> each other.
 
 <p>Primitive data types are <a for=/>equal</a> if they are also <a for=/>identical to</a> each

--- a/infra.bs
+++ b/infra.bs
@@ -708,17 +708,19 @@ Standard that should be reported and addressed.
 
 <h3 id=equality>Equality</h3>
 
-<p>Two values the same data type can be <a for=/>identical to</a> each other or <dfn export
-lt="equal|equals|shallow equal">equal</dfn>.
+<p>Two values the same data type can be <a for=/>equal</a> or <a for=/>identical to</a> each
+other.</p>
 
-<p>Variables or references are <dfn export>identical to</dfn> each other if they refer to the same
-value, or if they are both of the same primitive type, and that primitive type's definition of <a
-for=/>identical to</a> applies to them. A variable <dfn export>is</dfn> another variable when they
-are <a for=/>identical to</a> each other.
+<p>Primitive data types define an <dfn export lt="considered identical|identity check">identity
+check</dfn>, as primitive data types are compared by value rather than by reference.</p>
 
-<p>Primitive data types are <a for=/>equal</a> if they are also <a for=/>identical to</a> each
-other. Other data types must provide their own definition of <a for=/>equal</a>; Otherwise trying to
-compare them in that way must [=assert=].
+<p>Other data types may provide an <dfn export lt="considered equal|equality check">equality
+check</dfn>. This is useful, for example, for maintaining a <a for=/>set</a> of non-primitive items
+and guaranteeing uniqueness.</p>
+
+<p>When defining its own <a>equality check</a>, a data type must pass along the <a>equality
+context</a> argument it receives. This is used internally to assert that a nested <a>equality
+check</a> does not contain cyclic references.</p>
 
 <div class=example id=example-struct-equality>
  <ol>
@@ -745,6 +747,47 @@ compare them in that way must [=assert=].
  </ol>
 </div>
 
+<p>A <dfn>equality context</dfn> is a <a for=/>list</a>, representing values visited when checking
+for equality.</p>
+
+<div algorithm>
+<p>To check if <var>A</var> and <var>B</var> are <dfn export>equal</dfn> given an optional
+<a>equality context</a> <var>context</var> (default « »):
+ <ol>
+  <li><p>If <var>A</var> and <var>B</var> are not of the same data type, then return false.</p></li>
+
+  <li><p>If <var>A</var> is <a for=/>identical to</a> <var>B</var>, then return true.</p></li>
+
+  <li><p><a>Assert</a>: There is no item in <var>context</var>'s <a for=list>items</a> who is <a
+  for=/>identical to</a> either <var>A</var> or <var>B</var>.</p></li>
+
+  <li><p><a for=list>Append</a> <var>A</var> to <var>context</var>.</p></li>
+
+  <li><p><a for=list>Append</a> <var>B</var> to <var>context</var>.</p></li>
+
+  <li><p>Return the result of the <a>equality check</a> given <var>A</var> and
+  <var>B</var>.</p></li>
+ </ol>
+</div>
+
+<div algorithm=identity-check>
+<p>To check if <var>A</var> is <dfn export>identical to</dfn> <var>B</var> (<var>A</var> <dfn
+export>is</dfn> <var>B</var>):
+<ol>
+ <li><p>If <var>A</var> and <var>B</var> are not of the same type, then return false.</p></li>
+
+ <li><p>If <var>A</var> and <var>B</var> are references to the same value, then return
+ true.</p></li>
+
+ <li><p>If the common type of <var>A</var> and <var>B</var> does not define an <a>identity
+ check</a>, then return false.</p></li>
+
+ <li><p>Return the result of the type-specific <a>identity check</a> given <var>A</var> and
+ <var>B</var>.</p></li>
+</ol>
+</div>
+
+
 <h2 id=primitive-data-types>Primitive data types</h2>
 
 <h3 id=nulls>Nulls</h3>
@@ -756,7 +799,7 @@ JavaScript <b>null</b> value. [[!ECMA-262]]
 
 <p class=example id=example-null-return>If <var>input</var> is the empty string, then return null.
 
-<p>Null values are always <a for=/>identical to</a> each other.
+<p>Null values are always <a for=/>considered identical</a>.
 
 <h3 id=booleans>Booleans</h3>
 
@@ -764,8 +807,7 @@ JavaScript <b>null</b> value. [[!ECMA-262]]
 
 <p class=example id=example-boolean>Let <var ignore>elementSeen</var> be false.
 
-<p>Two <a>booleans</a> are <a for=/>identical to</a> each other when they are both true or both
-false.
+<p>Two <a>booleans</a> are <a for=/>considered identical</a> when they are both true or both false.
 
 <h3 id=numbers>Numbers</h3>
 
@@ -809,7 +851,7 @@ to 9223372036854775807 (&minus;2<sup>63</sup> to 2<sup>63</sup> &minus; 1), incl
 
 <hr>
 
-<p>Two numbers are <a for=/>identical to</a> each other when they are the same underlying number.
+<p>Two numbers are <a>considered identical</a> when they are the same underlying number.
 
 <h3 id=bytes>Bytes</h3>
 
@@ -859,7 +901,7 @@ contains, in the range 0x61 (a) to 0x7A (z), inclusive, by 0x20.
 <a>byte sequence</a> <var>B</var>, if the <a>byte-lowercase</a> of <var>A</var> is the
 <a>byte-lowercase</a> of <var>B</var>.
 
-<p>Two <a>byte sequences</a> are <a for=/>identical to</a> each other if their <a for="byte
+<p>Two <a>byte sequences</a> are <a>considered identical</a> if their <a for="byte
 sequence">lengths</a> are <a for=/>identical to</a> each other and all of their <a>bytes</a> are <a
 for=/>identical to</a> each other.
 
@@ -1104,8 +1146,7 @@ where <a>UTF-8 encode</a> comes into play.
 
 <p>A <a>string</a> <var>a</var> <dfn export for=string lt="is|identical to">is</dfn> or is
 <a for=string>identical to</a> a <a>string</a> <var>b</var> if it consists of the same sequence of
-<a>code units</a>. Those strings are considered <a for=/>identical to</a> each other for equality
-comparison.
+<a>code units</a>. Those strings are <a>considered identical</a>.
 
 <p>Except where otherwise stated, all string comparisons use <a for=string>is</a>.
 
@@ -1700,7 +1741,7 @@ the given index is 0, then <a for=list>prepend</a> the given item to the list.
 all of its <a for=list>items</a>.
 
 <p>A <a>list</a> <dfn export for=list,stack,queue,set lt=contain|exist>contains</dfn> an <a
-for=list>item</a> if the list has at least one item which <a>equals</a> that item. We can also
+for=list>item</a> if the list has at least one item which <a for=/>equals</a> that item. We can also
 denote this by saying that, for a <a>list</a> |list| and an index |index|, "|list|[|index|] <a
 for=list>exists</a>".
 
@@ -1719,8 +1760,8 @@ set of steps on each <a for=list>item</a> in order, use phrasing of the form
 "<a for=list>For each</a> |item| of <var ignore>list</var>", and then operate on |item| in the
 subsequent prose.
 
-<p>A [=/list=] |A| is <a for=/>equal</a> to a [=/list=] |B| if |A| has the same size as |B| and
-|A|[|i|] is <a for=/>equal</a> to |B|[|i|] for all [=indices=] |i| of |A|.
+<p>To [=Lists=] |A| and |B| are <a>considered equal</a> given |context| if |A| has the same size as
+|B| and |A|[|i|] is <a for=/>equal</a> to |B|[|i|] given |context| for all [=indices=] |i| of |A|.
 
 <div algorithm=slice>
 <p>To <dfn export for=list,stack,queue,set>slice</dfn> a <a>list</a> |list|, with an optional
@@ -2008,8 +2049,8 @@ a set of steps on each <a for=map>entry</a> in order, use phrasing of the form
 "<a for=map>For each</a> |key| → |value| of |map|", and then operate on |key| and |value| in the
 subsequent prose.
 
-<p>Two <a for=/>maps</a> are considered <a for=/>equal</a> when their <a for=map>entry</a> lists are
-<a for=/>equal</a>.
+<p>Two <a for=/>maps</a> are <a>considered equal</a> given |context| when their <a for=map>entry</a>
+lists are <a for=/>equal</a> given |context|.
 
 <p>To <dfn export for=map>clone</dfn> an <a>ordered map</a> |map| is to create a new
 <a>ordered map</a> |clone|, and, <a for=map>for each</a> |key| → |value| of |map|,
@@ -2060,8 +2101,8 @@ a <a>map</a> |map|, with a less than algorithm |lessThanAlgo|, is to create a ne
  </ol>
 </div>
 
-<p>Two <a>structs</a> are <a for=/>equal</a> if all of their corresponding <a for=struct>items</a>
-are <a for=/>equal</a>.
+<p>Two <a>structs</a> are <a>considered equal</a> given |context| if all of their corresponding <a
+for=struct>items</a> are <a for=/>equal</a> given |context|.
 
 <h4 id=tuples>Tuples</h4>
 

--- a/infra.bs
+++ b/infra.bs
@@ -1891,7 +1891,7 @@ of either with <var>replacement</var> and <a for=set>remove</a> all other instan
 <a for=list>for each</a> |item| of |set|, |superset| <a for=set>contains</a> |item|.
 
 <p>An <a>ordered set</a> |set| is an <dfn export for=set>equivalent subset</dfn> of another
-<a>ordered set</a> |superset| (and conversely, |superset| is a <dfn export for=set>equivalent
+<a>ordered set</a> |superset| (and conversely, |superset| is an <dfn export for=set>equivalent
 superset</dfn> of |set|) if, <a for=list>for each</a> |item| of |set|, |superset| <a
 for=set>contains an equivalent</a> of |item|.
 

--- a/infra.bs
+++ b/infra.bs
@@ -754,42 +754,38 @@ checks.</p>
 context">visited items</dfn>, initially « ».</p>
 
 <div algorithm>
-<p>To check if |A| and |B| are <dfn export>equal</dfn> given an optional
-<a>equality context</a> |context| (default a new <a>equality context</a>):
+<p>To check if |A| and |B| are <dfn export>equal</dfn> given an optional <a>equality context</a>
+|context| (default a new <a>equality context</a>):
 <ol>
  <li><p>If |A| and |B| are not of the same data type, then return false.
 
  <li><p>If |A| is <a for=/>identical to</a> |B|, then return true.
 
- <li><p>If the common data type of |A| and |B| does not define an <a>equality
- check</a>, then return false.
+ <li><p>If the common data type of |A| and |B| does not define an <a>equality check</a>, then return
+ false.
 
- <li><p><a>Assert</a>: There is no item in |context|'s <a for="equality context">visited
- items</a> that <a for=/>is</a> either |A| or |B|.
+ <li><p><a>Assert</a>: There is no item in |context|'s <a for="equality context">visited items</a>
+ that <a for=/>is</a> either |A| or |B|.
 
  <li><p><a for=list>Append</a> |A| to |context|'s <a for="equality context">visited items</a>.
 
  <li><p><a for=list>Append</a> |B| to |context|'s <a for="equality context">visited items</a>.
 
- <li><p>Return the result of the <a>equality check</a> given |A|, |B|, and
- |context|.
+ <li><p>Return the result of the <a>equality check</a> given |A|, |B|, and |context|.
 </ol>
 </div>
 
 <div algorithm=identity-check>
-<p>To check if |A| is <dfn export>identical to</dfn> |B| (|A| <dfn
-export>is</dfn> |B|):
+<p>To check if |A| is <dfn export>identical to</dfn> |B| (|A| <dfn export>is</dfn> |B|):
 <ol>
  <li><p>If |A| and |B| are not of the same data type, then return false.
 
- <li><p>If |A| and |B| are references to the same value, then return
- true.
+ <li><p>If |A| and |B| are references to the same value, then return true.
 
- <li><p>If the common data type of |A| and |B| does not define an <a>identity
- check</a>, then return false.
+ <li><p>If the common data type of |A| and |B| does not define an <a>identity check</a>, then return
+ false.
 
- <li><p>Return the result of the type-specific <a>identity check</a> given |A| and
- |B|.
+ <li><p>Return the result of the type-specific <a>identity check</a> given |A| and |B|.
 </ol>
 </div>
 
@@ -1766,8 +1762,8 @@ set of steps on each <a for=list>item</a> in order, use phrasing of the form
 "<a for=list>For each</a> |item| of <var ignore>list</var>", and then operate on |item| in the
 subsequent prose.
 
-<p>Two lists |A| and |B| are <a>considered equal</a> given |context| if |A| has the same size as
-|B| and |A|[|i|] is <a for=/>equal</a> to |B|[|i|] given |context| for all [=indices=] |i| of |A|.
+<p>Two lists |A| and |B| are <a>considered equal</a> given |context| if |A| has the same size as |B|
+and |A|[|i|] is <a for=/>equal</a> to |B|[|i|] given |context| for all [=indices=] |i| of |A|.
 
 <div algorithm=slice>
 <p>To <dfn export for=list,stack,queue,set>slice</dfn> a <a>list</a> |list|, with an optional

--- a/infra.bs
+++ b/infra.bs
@@ -1893,9 +1893,6 @@ of either with <var>replacement</var> and <a for=set>remove</a> all other instan
 <p>A [=/set=] |A| is <dfn export for=set lt=equal>unordered equal</dfn> to a [=/set=] |B| if |A| is
 a [=subset=] of |B| and |A| is a [=superset=] of |B|.
 
-<p>A [=/set=] |A| is <a for=/>equal</a> to a [=/set=] |B| if |A| is a [=subset=] of |B| and |B| is a
-[=subset=] of |A|.
-
 <p>The <dfn export for=set>intersection</dfn> of <a>ordered sets</a> |A| and |B|, is the result
 of creating a new <a>ordered set</a> |set| and, <a for=list>for each</a> |item| of |A|, if |B|
 <a for=set>contains</a> |item|, <a for=set>appending</a> |item| to |set|.


### PR DESCRIPTION
- `Identical to` (or `is`) is for primitives or by-reference comparisons
- `Equal` is for shallow comparison of structs/lists/maps or custom data types, and is used by internal map/lists algorithms such as `list/contains`. It checks for cyclical references internally, using a private-type visited list.
- Primitive data types specify their own "considered identical" overload.
- Data types must specify "considered equal" in order to participate in list-contains or be map keys.

Closes #664


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/infra/710.html" title="Last updated on Jul 6, 2026, 1:29 PM UTC (b3e4576)">Preview</a> | <a href="https://whatpr.org/infra/710/97e62b3...b3e4576.html" title="Last updated on Jul 6, 2026, 1:29 PM UTC (b3e4576)">Diff</a>